### PR TITLE
feat(icon): ✨ `css-icon` 支持直接传图标类名

### DIFF
--- a/docs/component/button.md
+++ b/docs/component/button.md
@@ -157,7 +157,8 @@
 | loading | 加载中按钮 | boolean | false |
 | text | 按钮文本 | string | - |
 | icon | 图标类名 | string | - |
-| class-prefix | 图标类名前缀 | string | wd-icon |
+| class-prefix | 类名前缀，用于使用自定义图标，用法参考 Icon 组件 | string | wd-icon |
+| css-icon | CSS 图标，用法参考 Icon 组件 | `boolean \| string` | false |
 | loading-props | 加载配置项 | `Partial<LoadingProps>` | - |
 | open-type | 开放能力类型，详见下方 `ButtonOpenType` | string | - |
 | hover-stop-propagation | 阻止祖先节点点击态 | boolean | false |

--- a/docs/component/button.md
+++ b/docs/component/button.md
@@ -126,11 +126,11 @@
 
 ### 图文按钮
 
-结合 `icon` 与内容展示图文按钮；结合 `classPrefix` 可使用自定义图标，参见 [Icon 自定义图标](/component/icon#自定义图标)。
+结合 `icon` 与内容展示图文按钮；结合 `class-prefix` 可使用自定义图标，参见 [Icon 自定义图标](/component/icon#自定义图标)。
 
 ```html
 <wd-button icon="download">下载</wd-button>
-<wd-button classPrefix="fish" icon="kehuishouwu">可回收</wd-button>
+<wd-button class-prefix="fish" icon="kehuishouwu">可回收</wd-button>
 ```
 
 ## 布局能力

--- a/docs/component/icon.md
+++ b/docs/component/icon.md
@@ -78,6 +78,9 @@
 ```html
 <wd-icon css-icon name="i-ep-apple" />
 <wd-icon css-icon name="i-carbon-sun" />
+
+<!-- 也可以直接传图标类名给 css-icon 而无需再传 name -->
+<wd-icon css-icon="i-carbon-sun" />
 ```
 
 ## Attributes
@@ -88,7 +91,7 @@
 | color	| 图标的颜色 | `string` | `inherit` |
 | size | 图标的字体大小 | `string \| number` | `inherit` |
 | class-prefix | 类名前缀，用于使用自定义图标 | `string` | `wd-icon` |
-| css-icon | 是否为 CSS 类名图标（如 UnoCSS 图标），为 true 时 name 直接作为 CSS class 使用 | `boolean` | `false` |
+| css-icon | CSS 图标，为 `true` 时 `name` 直接作为 CSS class 而不会拼接 `class-prefix` 前缀，也可以直接传图标类名 | `boolean \| string` | `false` |
 | custom-style | 根节点样式 | `string` | - |
 | custom-class | 根节点样式 | `string` | - |
 

--- a/docs/component/switch.md
+++ b/docs/component/switch.md
@@ -133,6 +133,11 @@ const beforeChange = (value) => {
 | active-action-icon | 激活状态操作按钮图标 | `string` | - |
 | active-icon | 激活状态图标，设置后会忽略 `active-text` | `string` | - |
 | inactive-icon | 非激活状态图标，设置后会忽略 `inactive-text` | `string` | - |
+| class-prefix | 类名前缀，用于使用自定义图标，用法参考 Icon 组件 | `string` | `'wd-icon'` |
+| inactive-action-css-icon | 非激活状态操作按钮 CSS 图标，用法参考 Icon 组件 | `boolean \| string` | `false` |
+| active-action-css-icon | 激活状态操作按钮 CSS 图标，用法参考 Icon 组件 | `boolean \| string` | `false` |
+| active-css-icon | 激活状态 CSS 图标，设置后将忽略 `active-text`，用法参考 Icon 组件 | `boolean \| string` | `false` |
+| inactive-css-icon | 非激活状态 CSS 图标，设置后将忽略 `inactive-text`，用法参考 Icon 组件 | `boolean \| string` | `false` |
 | active-text | 激活状态文本 | `string` | `''` |
 | inactive-text | 非激活状态文本 | `string` | `''` |
 | active-value | 激活值 | `boolean \| string \| number` | `true` |
@@ -144,7 +149,6 @@ const beforeChange = (value) => {
 | loading | 是否显示加载中 | `boolean` | `false` |
 | loading-props | 加载配置项 | `Partial<LoadingProps>` | - |
 | before-change | 修改前钩子 | `SwitchBeforeChange` | - |
-| class-prefix | 图标类名前缀 | `string` | `'wd-icon'` |
 | custom-class | 根节点自定义类名 | `string` | `''` |
 | custom-style | 根节点自定义样式 | `string` | `''` |
 

--- a/docs/component/toast.md
+++ b/docs/component/toast.md
@@ -144,7 +144,8 @@ toast.success({
 | z-index | 默认层级 | `number` | `100` |
 | cover | 是否显示透明遮罩层 | `boolean` | `false` |
 | icon-class | 默认图标类名 | `string` | `''` |
-| class-prefix | 图标类名前缀 | `string` | `wd-icon` |
+| class-prefix | 类名前缀，用于使用自定义图标，用法参考 Icon 组件 | `string` | `wd-icon` |
+| css-icon | CSS 图标，用法参考 Icon 组件 | `boolean \| string` | `false` |
 | opened | 完全展示后的回调 | <code>() =&gt; void</code> | - |
 | closed | 完全关闭后的回调 | <code>() =&gt; void</code> | - |
 | custom-class | 根节点自定义类名 | `string` | `''` |

--- a/docs/component/toast.md
+++ b/docs/component/toast.md
@@ -170,6 +170,7 @@ toast.success({
 | cover | 是否显示透明遮罩层 | `boolean` | `false` |
 | iconClass | 自定义图标类名 | `string` | `''` |
 | classPrefix | 自定义图标类名前缀 | `string` | `wd-icon` |
+| cssIcon | CSS 图标 | `boolean \| string` | `false` |
 | opened | 完全展示后的回调 | <code>() =&gt; void</code> | - |
 | closed | 完全关闭后的回调 | <code>() =&gt; void</code> | - |
 

--- a/docs/component/use-toast.md
+++ b/docs/component/use-toast.md
@@ -97,6 +97,7 @@ toast.close()
 | iconSize     | 左侧图标尺寸                            | number   | -                         | -          |
 | iconClass    | 自定义图标类名                          | string   | -                         | ''         |
 | classPrefix  | 类名前缀                                | string   | -                         | 'wd-icon'  |
+| cssIcon      | CSS 图标                                | boolean \| string   | -                  | false  |
 | position     | 提示信息框的位置                        | string   | top / middle / bottom     | middle-top |
 | zIndex       | toast 层级                              | number   | -                         | 100        |
 | loadingType  | 加载中图标类型                          | string   | ring                      | outline    |

--- a/docs/en-US/component/button.md
+++ b/docs/en-US/component/button.md
@@ -50,6 +50,14 @@ Set `variant="dashed"`.
 <wd-button variant="dashed">Primary Button</wd-button>
 ```
 
+### Soft
+
+Set `variant="soft"`.
+
+```html
+<wd-button variant="soft">Primary Button</wd-button>
+```
+
 ### Text
 
 Set `variant="text"`.
@@ -140,7 +148,7 @@ Set the `block` property.
 | Parameter | Description | Type | Default Value |
 | --- | --- | --- | --- |
 | type | Button type, optional values are `primary`, `success`, `info`, `warning`, `danger` | string | primary |
-| variant | Button variant, optional values are `base`, `plain`, `dashed`, `text` | string | base |
+| variant | Button variant, optional values are `base`, `plain`, `dashed`, `soft`, `text` | string | base |
 | size | Button size, optional values are `mini`, `small`, `medium`, `large` | string | medium |
 | round | Round button | boolean | false |
 | disabled | Disabled button | boolean | false |
@@ -149,7 +157,8 @@ Set the `block` property.
 | loading | Loading button | boolean | false |
 | text | Button text | string | - |
 | icon | Icon class name | string | - |
-| classPrefix | Icon class prefix | string | wd-icon |
+| class-prefix | Class prefix for custom icons (see Icon component) | string | wd-icon |
+| css-icon | CSS icon (see Icon component) | `boolean \| string` | false |
 | loading-props | Loading configuration | `Partial<LoadingProps>` | - |
 | open-type | Open capability type, see `ButtonOpenType` below | string | - |
 | hover-stop-propagation | Stop ancestor node click state | boolean | false |

--- a/docs/en-US/component/button.md
+++ b/docs/en-US/component/button.md
@@ -126,11 +126,11 @@ Set the `icon` property to display an icon button.
 
 ### Icon and Text Button
 
-Combine `icon` with content to display an icon and text button; combine with `classPrefix` to use custom icons, see [Icon Custom Icon](/component/icon#custom-icon).
+Combine `icon` with content to display an icon and text button; combine with `class-prefix` to use custom icons, see [Icon Custom Icon](/component/icon#custom-icon).
 
 ```html
 <wd-button icon="download">Download</wd-button>
-<wd-button classPrefix="fish" icon="kehuishouwu">Recyclable</wd-button>
+<wd-button class-prefix="fish" icon="kehuishouwu">Recyclable</wd-button>
 ```
 
 ## Layout Capability

--- a/docs/en-US/component/icon.md
+++ b/docs/en-US/component/icon.md
@@ -78,6 +78,9 @@ If your project uses [UnoCSS](https://unocss.dev/) or other CSS engines, you can
 ```html
 <wd-icon css-icon name="i-ep-apple" />
 <wd-icon css-icon name="i-carbon-sun" />
+
+<!-- You can also pass the class name directly to css-icon without using name -->
+<wd-icon css-icon="i-carbon-sun" />
 ```
 
 ## Attributes
@@ -88,7 +91,7 @@ If your project uses [UnoCSS](https://unocss.dev/) or other CSS engines, you can
 | color	| Icon color | `string` | `inherit` |
 | size | Icon font size | `string \| number` | `inherit` |
 | class-prefix | Class name prefix, used for custom icons | `string` | `wd-icon` |
-| css-icon | Whether it is a CSS class icon (such as UnoCSS icon). When true, name is directly used as CSS class | `boolean` | `false` |
+| css-icon | CSS icon. When `true`, `name` is used directly as the CSS class without prefix. You can also pass the class name directly | `boolean \| string` | `false` |
 | custom-style | Root node style | `string` | - |
 | custom-class | Root node style | `string` | - |
 

--- a/docs/en-US/component/switch.md
+++ b/docs/en-US/component/switch.md
@@ -133,6 +133,11 @@ const beforeChange = (value) => {
 | active-action-icon | Active state action button icon | `string` | - |
 | active-icon | Active state icon, ignores `active-text` when set | `string` | - |
 | inactive-icon | Inactive state icon, ignores `inactive-text` when set | `string` | - |
+| class-prefix | Class name prefix for using custom icons (see Icon component) | `string` | `'wd-icon'` |
+| inactive-action-css-icon | CSS icon for the inactive state action button (see Icon component) | `boolean \| string` | `false` |
+| active-action-css-icon | CSS icon for the active state action button (see Icon component) | `boolean \| string` | `false` |
+| active-css-icon | CSS icon for the active state. When set, `active-text` will be ignored (see Icon component) | `boolean \| string` | `false` |
+| inactive-css-icon | CSS icon for the inactive state. When set, `inactive-text` will be ignored (see Icon component) | `boolean \| string` | `false` |
 | active-text | Active state text | `string` | `''` |
 | inactive-text | Inactive state text | `string` | `''` |
 | active-value | Active value | `boolean \| string \| number` | `true` |
@@ -144,7 +149,6 @@ const beforeChange = (value) => {
 | loading | Whether to show loading | `boolean` | `false` |
 | loading-props | Loading configuration | `Partial<LoadingProps>` | - |
 | before-change | Hook before modification | `SwitchBeforeChange` | - |
-| class-prefix | Icon class name prefix | `string` | `'wd-icon'` |
 | custom-class | Root node custom class name | `string` | `''` |
 | custom-style | Root node custom style | `string` | `''` |
 

--- a/docs/en-US/component/toast.md
+++ b/docs/en-US/component/toast.md
@@ -144,7 +144,8 @@ toast.success({
 | z-index | Default z-index level | `number` | `100` |
 | cover | Whether to show transparent mask layer | `boolean` | `false` |
 | icon-class | Default icon class name | `string` | `''` |
-| class-prefix | Icon class name prefix | `string` | `wd-icon` |
+| class-prefix | Class prefix for custom icons (see Icon component) | string | wd-icon |
+| css-icon | CSS icon (see Icon component) | `boolean \| string` | false |
 | opened | Callback after fully displayed | `() => void` | - |
 | closed | Callback after fully closed | `() => void` | - |
 | custom-class | Root node custom class name | `string` | `''` |
@@ -169,6 +170,7 @@ toast.success({
 | cover | Whether to show transparent mask layer | `boolean` | `false` |
 | iconClass | Custom icon class name | `string` | `''` |
 | classPrefix | Custom icon class name prefix | `string` | `wd-icon` |
+| cssIcon | CSS icon | `boolean \| string` | `false` |
 | opened | Callback after fully displayed | `() => void` | - |
 | closed | Callback after fully closed | `() => void` | - |
 

--- a/docs/en-US/component/use-toast.md
+++ b/docs/en-US/component/use-toast.md
@@ -88,20 +88,21 @@ toast.close()
 
 ### Options
 
-| Parameter         | Description                                    | Type     | Optional Values                    | Default Value     |
-|--------------|----------------------------------------|----------|---------------------------|------------|
-| msg          | Message content                                | string   | -                         | ''         |
-| duration     | Duration in ms, 0 means no auto-close  | number   | -                         | 2000       |
-| direction    | Layout direction                                | string   | vertical / horizontal     | horizontal |
-| iconName     | Icon type                                | string   | success / error / warning | ''         |
-| iconSize     | Left icon size                            | number   | -                         | -          |
-| iconClass    | Custom icon class name                          | string   | -                         | ''         |
-| classPrefix  | Class name prefix                                | string   | -                         | 'wd-icon'  |
-| position     | Position of prompt message box                        | string   | top / middle / bottom     | middle-top |
-| zIndex       | toast z-index                              | number   | -                         | 100        |
-| loadingType  | Loading icon type                          | string   | ring                      | outline    |
-| loadingColor | Loading icon color                          | string   | -                         | #4D80F0    |
-| selector     | Specify unique identifier                            | string   | -                         | ''         |
-| cover        | Whether there is a transparent cover                     | boolean  | -                         | false      |
-| opened       | Callback function after fully displayed                     | Function | -                         | -          |
-| closed       | Callback function after fully closed                     | Function | -                         | -          |
+| Parameter    | Description                             | Type                | Optional Values           | Default Value |
+|--------------|-----------------------------------------|---------------------|---------------------------|---------------|
+| msg          | Message content                         | string              | -                         | ''            |
+| duration     | Duration in ms, 0 means no auto-close   | number              | -                         | 2000          |
+| direction    | Layout direction                        | string              | vertical / horizontal     | horizontal    |
+| iconName     | Icon type                               | string              | success / error / warning | ''            |
+| iconSize     | Left icon size                          | number              | -                         | -             |
+| iconClass    | Custom icon class name                  | string              | -                         | ''            |
+| classPrefix  | Class name prefix                       | string              | -                         | 'wd-icon'     |
+| cssIcon      | CSS icon                                | `boolean \| string` | -                         | false         |
+| position     | Position of prompt message box          | string              | top / middle / bottom     | middle-top    |
+| zIndex       | toast z-index                           | number              | -                         | 100           |
+| loadingType  | Loading icon type                       | string              | ring                      | outline       |
+| loadingColor | Loading icon color                      | string              | -                         | #4D80F0       |
+| selector     | Specify unique identifier               | string              | -                         | ''            |
+| cover        | Whether there is a transparent cover    | boolean             | -                         | false         |
+| opened       | Callback function after fully displayed | Function            | -                         | -             |
+| closed       | Callback function after fully closed    | Function            | -                         | -             |

--- a/src/uni_modules/wot-ui/components/wd-button/types.ts
+++ b/src/uni_modules/wot-ui/components/wd-button/types.ts
@@ -106,10 +106,19 @@ export const buttonProps = {
    */
   icon: String,
   /**
-   * 类名前缀，用于使用自定义图标，用法参考Icon组件
+   * 类名前缀，用于使用自定义图标，用法参考 Icon 组件
    * 默认值: 'wd-icon'
    */
   classPrefix: makeStringProp('wd-icon'),
+  /**
+   * CSS 图标，用法参考 Icon 组件
+   * 类型: boolean | string
+   * 默认值: false
+   */
+  cssIcon: {
+    type: [Boolean, String],
+    default: false
+  },
   /**
    * 加载中按钮
    * 默认值: false

--- a/src/uni_modules/wot-ui/components/wd-button/wd-button.vue
+++ b/src/uni_modules/wot-ui/components/wd-button/wd-button.vue
@@ -42,7 +42,7 @@
   >
     <view class="wd-button__content">
       <wd-loading v-if="loading" v-bind="customLoadingProps"></wd-loading>
-      <wd-icon v-else-if="icon" custom-class="wd-button__icon" :name="icon" :classPrefix="classPrefix"></wd-icon>
+      <wd-icon v-else-if="icon || cssIcon" custom-class="wd-button__icon" :name="icon" :class-prefix="classPrefix" :css-icon="cssIcon"></wd-icon>
       <view class="wd-button__text" v-if="$slots.default || text">
         <slot>{{ text }}</slot>
       </view>

--- a/src/uni_modules/wot-ui/components/wd-button/wd-button.vue
+++ b/src/uni_modules/wot-ui/components/wd-button/wd-button.vue
@@ -107,7 +107,7 @@ const openTypeValue = computed(() => {
  * 是否仅展示图标
  */
 const isIcon = computed(() => {
-  return !slots.default && !props.text && props.icon
+  return !slots.default && !props.text && !!(props.icon || props.cssIcon)
 })
 
 /**

--- a/src/uni_modules/wot-ui/components/wd-icon/types.ts
+++ b/src/uni_modules/wot-ui/components/wd-icon/types.ts
@@ -7,7 +7,7 @@
  * @FilePath: /wot-ui/src/uni_modules/wot-ui/components/wd-icon/types.ts
  * 记得注释
  */
-import { baseProps, makeBooleanProp, makeRequiredProp, makeStringProp, numericProp } from '../../common/props'
+import { baseProps, makeStringProp, numericProp } from '../../common/props'
 import type { ExtractPropTypes } from 'vue'
 
 export const iconProps = {
@@ -16,7 +16,7 @@ export const iconProps = {
    * 图标名称，支持使用图片链接
    * 类型: string
    */
-  name: makeRequiredProp(String),
+  name: makeStringProp(''),
   /**
    * 图标颜色
    * 类型: string
@@ -34,11 +34,14 @@ export const iconProps = {
    */
   classPrefix: makeStringProp('wd-icon'),
   /**
-   * 是否为 CSS 类名图标（如 UnoCSS 图标），为 true 时 name 直接作为 CSS class 使用
-   * 类型: boolean
+   * CSS 图标，为 true 时 name 直接作为 CSS class 而不会拼接 class-prefix 前缀，也可以直接传图标类名
+   * 类型: boolean | string
    * 默认值: false
    */
-  cssIcon: makeBooleanProp(false)
+  cssIcon: {
+    type: [Boolean, String],
+    default: false
+  }
 }
 
 export type IconProps = ExtractPropTypes<typeof iconProps>

--- a/src/uni_modules/wot-ui/components/wd-icon/wd-icon.vue
+++ b/src/uni_modules/wot-ui/components/wd-icon/wd-icon.vue
@@ -1,5 +1,5 @@
 <template>
-  <view @click="handleClick" :class="rootClass" :style="rootStyle">
+  <view :class="rootClass" :style="rootStyle" @click="handleClick">
     <image v-if="isImage" class="wd-icon__image" :src="name"></image>
   </view>
 </template>
@@ -19,7 +19,7 @@ export default {
 </script>
 
 <script lang="ts" setup>
-import { computed, type CSSProperties } from 'vue'
+import { computed, normalizeClass, type CSSProperties } from 'vue'
 import { addUnit, isDef, objToStyle } from '../../common/util'
 import { iconProps } from './types'
 
@@ -31,12 +31,26 @@ const isImage = computed(() => {
 })
 
 const rootClass = computed(() => {
-  if (props.cssIcon) {
-    // CSS 图标模式：name 直接作为 class，不使用 iconfont
-    return `wd-icon wd-icon--css ${props.name} ${props.customClass}`
+  const clazz: Record<string, boolean> = {
+    'wd-icon': true
   }
-  const prefix = props.classPrefix
-  return `wd-icon ${prefix} ${props.customClass} ${isImage.value ? 'wd-icon--image' : prefix + '-' + props.name}`
+
+  if (props.cssIcon) {
+    clazz['wd-icon--css'] = true
+
+    if (typeof props.cssIcon === 'string') {
+      clazz[props.cssIcon] = true
+    } else {
+      clazz[props.name] = true
+    }
+  } else if (isImage.value) {
+    clazz['wd-icon--image'] = true
+  } else {
+    clazz[props.classPrefix] = true
+    clazz[`${props.classPrefix}-${props.name}`] = true
+  }
+
+  return normalizeClass([clazz, props.customClass])
 })
 
 const rootStyle = computed(() => {

--- a/src/uni_modules/wot-ui/components/wd-switch/types.ts
+++ b/src/uni_modules/wot-ui/components/wd-switch/types.ts
@@ -36,6 +36,38 @@ export const switchProps = {
    */
   inactiveIcon: String,
   /**
+   * 类名前缀，用于使用自定义图标，用法参考 Icon 组件
+   */
+  classPrefix: makeStringProp('wd-icon'),
+  /**
+   * 非激活状态操作按钮 CSS 图标，用法参考 Icon 组件
+   */
+  inactiveActionCssIcon: {
+    type: [Boolean, String],
+    default: false
+  },
+  /**
+   * 激活状态操作按钮 CSS 图标，用法参考 Icon 组件
+   */
+  activeActionCssIcon: {
+    type: [Boolean, String],
+    default: false
+  },
+  /**
+   * 激活状态 CSS 图标，设置后将忽略 `activeText`，用法参考 Icon 组件
+   */
+  activeCssIcon: {
+    type: [Boolean, String],
+    default: false
+  },
+  /**
+   * 非激活状态 CSS 图标，设置后将忽略 `inactiveText`，用法参考 Icon 组件
+   */
+  inactiveCssIcon: {
+    type: [Boolean, String],
+    default: false
+  },
+  /**
    * 激活状态文本
    */
   activeText: makeStringProp(''),
@@ -84,10 +116,6 @@ export const switchProps = {
   /**
    * 在改变前执行的函数
    */
-  beforeChange: Function as PropType<SwitchBeforeChange>,
-  /**
-   * 自定义类名
-   */
-  classPrefix: makeStringProp('wd-icon')
+  beforeChange: Function as PropType<SwitchBeforeChange>
 }
 export type SwitchProps = ExtractPropTypes<typeof switchProps>

--- a/src/uni_modules/wot-ui/components/wd-switch/wd-switch.vue
+++ b/src/uni_modules/wot-ui/components/wd-switch/wd-switch.vue
@@ -1,12 +1,24 @@
 <template>
   <view :class="rootClass" :style="rootStyle" @click="switchValue">
     <view class="wd-switch__inner" :style="innerStyle">
-      <wd-icon custom-class="wd-switch__inner-icon" :name="innerIcon" v-if="innerIcon" :class-prefix="classPrefix"></wd-icon>
+      <wd-icon
+        v-if="innerIcon || innerCssIcon"
+        custom-class="wd-switch__inner-icon"
+        :name="innerIcon"
+        :class-prefix="classPrefix"
+        :css-icon="innerCssIcon"
+      ></wd-icon>
       <text v-else class="wd-switch__inner-text">{{ isActive ? activeText : inactiveText }}</text>
     </view>
     <view class="wd-switch__action">
-      <wd-loading v-bind="customLoadingProps" v-if="loading"></wd-loading>
-      <wd-icon custom-class="wd-switch__action-icon" :name="actionIcon" v-else-if="actionIcon" :class-prefix="classPrefix"></wd-icon>
+      <wd-loading v-if="loading" v-bind="customLoadingProps"></wd-loading>
+      <wd-icon
+        v-else-if="actionIcon || actionCssIcon"
+        custom-class="wd-switch__action-icon"
+        :name="actionIcon"
+        :class-prefix="classPrefix"
+        :css-icon="actionCssIcon"
+      ></wd-icon>
     </view>
   </view>
 </template>
@@ -62,8 +74,16 @@ const innerIcon = computed(() => {
   return isActive.value ? props.activeIcon : props.inactiveIcon
 })
 
+const innerCssIcon = computed(() => {
+  return isActive.value ? props.activeCssIcon : props.inactiveCssIcon
+})
+
 const actionIcon = computed(() => {
   return isActive.value ? props.activeActionIcon : props.inactiveActionIcon
+})
+
+const actionCssIcon = computed(() => {
+  return isActive.value ? props.activeActionCssIcon : props.inactiveActionCssIcon
 })
 
 const customLoadingProps = computed<Partial<LoadingProps>>(() => {

--- a/src/uni_modules/wot-ui/components/wd-toast/types.ts
+++ b/src/uni_modules/wot-ui/components/wd-toast/types.ts
@@ -45,6 +45,10 @@ export type ToastOptions = {
    */
   classPrefix?: string
   /**
+   * CSS 图标
+   */
+  cssIcon?: boolean | string
+  /**
    * 完全展示后的回调函数
    */
   opened?: () => void
@@ -167,13 +171,19 @@ export const toastProps = {
     default: ''
   },
   /**
-   * 类名前缀
+   * 类名前缀，用于使用自定义图标，用法参考 Icon 组件
    * @type {string}
    * @default 'wd-icon'
    */
-  classPrefix: {
-    type: String,
-    default: 'wd-icon'
+  classPrefix: makeStringProp('wd-icon'),
+  /**
+   * CSS 图标，用法参考 Icon 组件
+   * @type {boolean | string}
+   * @default false
+   */
+  cssIcon: {
+    type: [Boolean, String],
+    default: false
   },
   /**
    * 完全展示后的回调函数

--- a/src/uni_modules/wot-ui/components/wd-toast/wd-toast.vue
+++ b/src/uni_modules/wot-ui/components/wd-toast/wd-toast.vue
@@ -19,11 +19,12 @@
         :name="toastIcon[iconName]"
       ></wd-icon>
       <wd-icon
-        v-else-if="iconClass"
+        v-else-if="iconClass || cssIcon"
         :custom-class="`wd-toast__icon ${direction === 'vertical' ? 'is-vertical' : ''}`"
         :size="iconSize"
         :class-prefix="classPrefix"
         :name="iconClass"
+        :css-icon="cssIcon"
       ></wd-icon>
       <!--文本-->
       <view v-if="msg" :class="`wd-toast__msg ${direction === 'vertical' ? 'is-vertical' : ''}`">{{ msg }}</view>
@@ -68,6 +69,7 @@ const loadingSize = ref<string>() // loading大小
 const cover = ref<boolean>(false) // 是否存在遮罩层
 const classPrefix = ref<string>('wd-icon') // 图标前缀
 const iconClass = ref<string>('') // 图标类名
+const cssIcon = ref<boolean | string>(false) // CSS 图标
 const direction = ref<ToastDirection>('horizontal') // toast布局方向
 
 let opened: (() => void) | null = null
@@ -108,7 +110,7 @@ const transitionStyle = computed(() => {
 
 const rootClass = computed(() => {
   return `wd-toast ${props.customClass} wd-toast--${position.value} ${
-    (iconName.value !== 'loading' || msg.value) && (iconName.value || iconClass.value) ? 'wd-toast--with-icon' : ''
+    (iconName.value !== 'loading' || msg.value) && (iconName.value || iconClass.value || cssIcon.value) ? 'wd-toast--with-icon' : ''
   } ${iconName.value === 'loading' && !msg.value ? 'wd-toast--loading' : ''} ${direction.value === 'vertical' ? 'is-vertical' : ''}`
 })
 
@@ -139,6 +141,7 @@ function reset(option: ToastOptions) {
 function mergeOptionsWithProps(option: ToastOptions, props: ToastProps) {
   iconName.value = isDef(option.iconName!) ? option.iconName! : props.iconName
   iconClass.value = isDef(option.iconClass!) ? option.iconClass! : props.iconClass
+  cssIcon.value = isDef(option.cssIcon!) ? option.cssIcon! : props.cssIcon
   msg.value = isDef(option.msg!) ? option.msg! : props.msg
   position.value = isDef(option.position!) ? option.position! : props.position
   zIndex.value = isDef(option.zIndex!) ? option.zIndex! : props.zIndex


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/wot-ui/wot-ui/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [x] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 💡 需求背景和解决方案

`css-icon` 支持直接传图标类名：

```html
<wd-icon css-icon="i-carbon-sun"></wd-icon>
```

并补充支持 icon 配置组件的 `css-icon` 属性。

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 为 Button、Icon、Switch 和 Toast 添加了可通过 CSS 类渲染的图标支持（新增 cssIcon / css-icon 配置）；Switch 还支持针对激活/非激活与动作区域的独立 CSS 图标配置。
  * Button 新增 variant="soft" 可选项。

* **文档**
  * 更新了 Button、Icon、Switch、Toast 和 useToast 文档，说明 cssIcon 用法、类型（boolean | string）及示例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->