### PR TITLE
feat: ✨ 调整 button 组件高度由 padding 撑开转为固定高度

### DIFF
--- a/src/subPages/button/Index.vue
+++ b/src/subPages/button/Index.vue
@@ -91,6 +91,9 @@
           <view class="page-button__row">
             <wd-button v-for="item in typeItems" :key="`icon-round-${item.type}`" icon="delete" :type="item.type" variant="plain" round></wd-button>
           </view>
+          <view class="page-button__row">
+            <wd-button v-for="item in typeItems" :key="`icon-round-${item.type}`" icon="delete" :type="item.type" :size="item.size" round></wd-button>
+          </view>
         </demo-group-item>
         <demo-group-item :title="$t('tu-wen-an-niu')">
           <wd-button icon="download">{{ $t('xia-zai') }}</wd-button>
@@ -127,11 +130,11 @@ import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
 const typeItems = [
-  { type: 'primary', textKey: 'zhu-yao-an-niu' },
-  { type: 'success', textKey: 'cheng-gong-an-niu-0' },
-  { type: 'info', textKey: 'xin-xi-an-niu' },
-  { type: 'warning', textKey: 'jing-gao-an-niu-0' },
-  { type: 'danger', textKey: 'wei-xian-an-niu' }
+  { type: 'primary', textKey: 'zhu-yao-an-niu', size: 'large' },
+  { type: 'success', textKey: 'cheng-gong-an-niu-0', size: 'medium' },
+  { type: 'info', textKey: 'xin-xi-an-niu', size: 'small' },
+  { type: 'warning', textKey: 'jing-gao-an-niu-0', size: 'mini' },
+  { type: 'danger', textKey: 'wei-xian-an-niu', size: 'small' }
 ] as const
 
 const sizeItems = computed<Array<{ size: ButtonSize; text: string }>>(() => [

--- a/src/uni_modules/wot-ui/components/wd-button/index.scss
+++ b/src/uni_modules/wot-ui/components/wd-button/index.scss
@@ -124,14 +124,6 @@ $button-font-size-small: var(--wot-button-font-size-small, $typography-body-size
 $button-font-size-medium: var(--wot-button-font-size-medium, $typography-body-size-extra-large) !default;
 // large 尺寸文字字号
 $button-font-size-large: var(--wot-button-font-size-large, $typography-body-size-extra-large) !default;
-// mini 尺寸文字行高
-$button-line-height-mini: var(--wot-button-line-height-mini, $typography-body-line-height-size-main) !default;
-// small 尺寸文字行高
-$button-line-height-small: var(--wot-button-line-height-small, $typography-body-line-height-size-main) !default;
-// medium 尺寸文字行高
-$button-line-height-medium: var(--wot-button-line-height-medium, $typography-body-line-height-size-extra-large) !default;
-// large 尺寸文字行高
-$button-line-height-large: var(--wot-button-line-height-large, $typography-body-line-height-size-extra-large) !default;
 // mini 尺寸内边距
 $button-padding-mini: var(--wot-button-padding-mini, $padding-zero $padding-loose) !default;
 // small 尺寸内边距

--- a/src/uni_modules/wot-ui/components/wd-button/index.scss
+++ b/src/uni_modules/wot-ui/components/wd-button/index.scss
@@ -132,22 +132,22 @@ $button-line-height-small: var(--wot-button-line-height-small, $typography-body-
 $button-line-height-medium: var(--wot-button-line-height-medium, $typography-body-line-height-size-extra-large) !default;
 // large 尺寸文字行高
 $button-line-height-large: var(--wot-button-line-height-large, $typography-body-line-height-size-extra-large) !default;
-// mini 尺寸左右内边距
-$button-left-right-padding-mini: var(--wot-button-left-right-padding-mini, $padding-loose) !default;
-// small 尺寸左右内边距
-$button-left-right-padding-small: var(--wot-button-left-right-padding-small, $padding-loose) !default;
-// medium 尺寸左右内边距
-$button-left-right-padding-medium: var(--wot-button-left-right-padding-medium, $padding-extra-loose) !default;
-// large 尺寸左右内边距
-$button-left-right-padding-large: var(--wot-button-left-right-padding-large, $padding-super-loose) !default;
-// mini 尺寸上下内边距
-$button-up-down-padding-mini: var(--wot-button-up-down-padding-mini, $padding-super-tight) !default;
-// small 尺寸上下内边距
-$button-up-down-padding-small: var(--wot-button-up-down-padding-small, $padding-extra-tight) !default;
-// medium 尺寸上下内边距
-$button-up-down-padding-medium: var(--wot-button-up-down-padding-medium, $padding-tight) !default;
-// large 尺寸上下内边距
-$button-up-down-padding-large: var(--wot-button-up-down-padding-large, $padding-main) !default;
+// mini 尺寸内边距
+$button-padding-mini: var(--wot-button-padding-mini, $padding-zero $padding-loose) !default;
+// small 尺寸内边距
+$button-padding-small: var(--wot-button-padding-small, $padding-zero $padding-loose) !default;
+// medium 尺寸内边距
+$button-padding-medium: var(--wot-button-padding-medium, $padding-zero $padding-extra-loose) !default;
+// large 尺寸内边距
+$button-padding-large: var(--wot-button-padding-large, $padding-zero $padding-super-loose) !default;
+// mini 尺寸高度
+$button-height-mini: var(--wot-button-height-mini, $n-28) !default;
+// small 尺寸高度
+$button-height-small: var(--wot-button-height-small, $n-32) !default;
+// medium 尺寸高度
+$button-height-medium: var(--wot-button-height-medium, $n-40) !default;
+// large 尺寸高度
+$button-height-large: var(--wot-button-height-large, $n-44) !default;
 // mini 尺寸仅图标按钮内边距
 $button-only-icon-padding-mini: var(--wot-button-only-icon-padding-mini, $padding-super-tight) !default;
 // small 尺寸仅图标按钮内边距
@@ -155,7 +155,7 @@ $button-only-icon-padding-small: var(--wot-button-only-icon-padding-small, $padd
 // medium 尺寸仅图标按钮内边距
 $button-only-icon-padding-medium: var(--wot-button-only-icon-padding-medium, $padding-tight) !default;
 // large 尺寸仅图标按钮内边距
-$button-only-icon-padding-large: var(--wot-button-only-icon-padding-large, $padding-loose) !default;
+$button-only-icon-padding-large: var(--wot-button-only-icon-padding-large, $padding-main) !default;
 // mini 尺寸图标与文字间距
 $button-spacing-mini: var(--wot-button-spacing-mini, $spacing-super-tight) !default;
 // small 尺寸图标与文字间距
@@ -245,37 +245,33 @@ $button-types: (
 // 按钮尺寸配置映射
 $button-sizes: (
   "mini": (
-    "padding-y": $button-up-down-padding-mini,
-    "padding-x": $button-left-right-padding-mini,
+    "height": $button-height-mini,
+    "padding": $button-padding-mini,
     "font-size": $button-font-size-mini,
-    "line-height": $button-line-height-mini,
     "icon-font-size": $button-size-icon-mini,
     "spacing": $button-spacing-mini,
     "icon-padding": $button-only-icon-padding-mini
   ),
   "small": (
-    "padding-y": $button-up-down-padding-small,
-    "padding-x": $button-left-right-padding-small,
+    "height": $button-height-small,
+    "padding": $button-padding-small,
     "font-size": $button-font-size-small,
-    "line-height": $button-line-height-small,
     "icon-font-size": $button-size-icon-small,
     "spacing": $button-spacing-small,
     "icon-padding": $button-only-icon-padding-small
   ),
   "medium": (
-    "padding-y": $button-up-down-padding-medium,
-    "padding-x": $button-left-right-padding-medium,
+    "height": $button-height-medium,
+    "padding": $button-padding-medium,
     "font-size": $button-font-size-medium,
-    "line-height": $button-line-height-medium,
     "icon-font-size": $button-size-icon-medium,
     "spacing": $button-spacing-medium,
     "icon-padding": $button-only-icon-padding-medium
   ),
   "large": (
-    "padding-y": $button-up-down-padding-large,
-    "padding-x": $button-left-right-padding-large,
+    "height": $button-height-large,
+    "padding": $button-padding-large,
     "font-size": $button-font-size-large,
-    "line-height": $button-line-height-large,
     "icon-font-size": $button-size-icon-large,
     "spacing": $button-spacing-large,
     "icon-padding": $button-only-icon-padding-large
@@ -305,6 +301,7 @@ $button-variants: (
   margin-left: initial;
   margin-right: initial;
   border-radius: $button-radius-main;
+  flex-shrink: 0;
 
   &::after {
     position: absolute;
@@ -455,14 +452,14 @@ $button-variants: (
   @each $size,
   $conf in $button-sizes {
     @include when($size) {
-      padding: map.get($conf, "padding-y") map.get($conf, "padding-x");
+      height: map.get($conf, "height");
+      padding: map.get($conf, "padding");
       font-size: map.get($conf, "font-size");
-      line-height: map.get($conf, "line-height");
+      line-height: map.get($conf, "height");
       font-weight: normal;
 
       :deep(.wd-button__icon) {
         font-size: map.get($conf, "icon-font-size");
-        line-height: 1;
 
         + .wd-button__text {
           margin-left: map.get($conf, "spacing");
@@ -470,6 +467,7 @@ $button-variants: (
       }
 
       @include when(icon) {
+        min-width: map.get($conf, "height");
         padding: map.get($conf, "icon-padding");
       }
     }


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/wot-ui/wot-ui/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
无
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
原 button 高度由 padding 撑开，在某些场景会造成高度异常，例如flex 布局等，故而将 button 组件高度调整为固定高度。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 图标按钮现已支持多种尺寸选项

* **样式改进**
  * 优化了按钮组件的尺寸和间距系统
  * 增强了 flex 布局中按钮的尺寸稳定性
  * 统一了跨尺寸的样式配置机制

<!-- end of auto-generated comment: release notes by coderabbit.ai -->