### PR TITLE
fix: 🐛 修复 Dialog 覆盖 Popup 样式权重较低导致被其他 Popup 覆盖的问题

### DIFF
--- a/src/uni_modules/wot-ui/components/wd-curtain/index.scss
+++ b/src/uni_modules/wot-ui/components/wd-curtain/index.scss
@@ -13,11 +13,11 @@ $curtain-content-close-inset: var(--wot-curtain-content-close-inset, $spacing-ex
 :deep() {
   .wd-popup.wd-curtain {
     background: transparent;
+    overflow-y: visible;
   }
 
   @include b(curtain) {
     border-radius: $curtain-content-radius;
-    overflow-y: visible !important;
     font-size: 0;
 
     @include e(content) {

--- a/src/uni_modules/wot-ui/components/wd-curtain/index.scss
+++ b/src/uni_modules/wot-ui/components/wd-curtain/index.scss
@@ -11,10 +11,13 @@ $curtain-content-close-size: var(--wot-curtain-content-close-size, $n-32) !defau
 $curtain-content-close-inset: var(--wot-curtain-content-close-inset, $spacing-extra-loose) !default;
 
 :deep() {
+  .wd-popup.wd-curtain {
+    background: transparent;
+  }
+
   @include b(curtain) {
     border-radius: $curtain-content-radius;
     overflow-y: visible !important;
-    background: transparent;
     font-size: 0;
 
     @include e(content) {

--- a/src/uni_modules/wot-ui/components/wd-dialog/index.scss
+++ b/src/uni_modules/wot-ui/components/wd-dialog/index.scss
@@ -89,8 +89,10 @@ $dialog-action-text-button-padding: var(--wot-dialog-action-text-button-padding,
 $dialog-action-text-border: var(--wot-dialog-action-text-border, $stroke-light) !default;
 
 
-:deep(.wd-dialog) {
-  background: transparent;
+:deep() {
+  .wd-popup.wd-dialog {
+    background: transparent;
+  }
 }
 
 @include b(dialog) {
@@ -108,14 +110,14 @@ $dialog-action-text-border: var(--wot-dialog-action-text-border, $stroke-light) 
     width: 100%;
     height: auto;
     border-radius: $dialog-img-border-radius;
-    
+
     &+.wd-dialog__title {
-      margin-top: $dialog-body-element-spacing-large; 
+      margin-top: $dialog-body-element-spacing-large;
     }
 
     &+.wd-dialog__content {
-      margin-top: $dialog-body-element-spacing-large; 
-      
+      margin-top: $dialog-body-element-spacing-large;
+
       .wd-dialog__body.is-prompt & {
         margin-top: $dialog-body-element-spacing;
       }


### PR DESCRIPTION
✅ Closes: #21

<!--
请务必阅读[贡献指南](https://github.com/wot-ui/wot-ui/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
#21 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

**问题背景**

在微信小程序中，当页面同时存在 `wd-dialog` 与其他基于 `wd-popup` 实现的组件（如 `wd-picker`、`wd-action-sheet` 等）时，`wd-dialog` 的圆角效果会丢失；`wd-curtain` 同样存在背景透明失效的问题。

**根本原因**

`wd-dialog` 和 `wd-curtain` 均以 `wd-popup` 为底层渲染容器，并通过 `custom-class` 将自身类名（`wd-dialog` / `wd-curtain`）注入到 `wd-popup` 的根节点，使该节点同时携带 `.wd-popup` 和组件自身的类。

各组件 SCSS 通过 `:deep(.wd-dialog)` / `:deep(.wd-curtain)` 将 `background` 覆写为 `transparent`，选择器优先级为 `[0,1,0]`，与 `wd-popup/index.scss` 中 `.wd-popup { background: $popup-bg }` 的优先级完全相同。

在微信小程序中，每个使用到的组件的样式表都会被全局注入到页面。当页面上存在其他基于 `wd-popup` 的组件时，`wd-popup` 的样式表会在 `wd-dialog` / `wd-curtain` 的覆写规则之后注入，导致 `.wd-popup { background }` 最终生效，`background: transparent` 被覆盖，进而造成圆角/透明背景异常。

**解决方案**

将覆写规则的选择器由单类提升为双类（`.wd-popup` + 组件自身类），使优先级从 `[0,1,0]` 提升至 `[0,2,0]`，永远压过 `.wd-popup` 的单类规则，彻底与样式注入顺序解耦：

```scss
/* wd-dialog/index.scss */
- :deep(.wd-dialog) {
+ :deep(.wd-popup.wd-dialog) {
    background: transparent;
  }

/* wd-curtain/index.scss */
+ :deep(.wd-popup.wd-curtain) {
+   background: transparent;
+ }
```

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **样式优化**
  * 调整对话框和幕帘组件的背景透明度渲染方式，改进视觉表现

<!-- end of auto-generated comment: release notes by coderabbit.ai -->