### PR TITLE
fix: 🐛 更新 Dialog 组件关闭逻辑，支持通过点击关闭按钮触发关闭操作并返回相应的 action

### DIFF
--- a/docs/component/dialog.md
+++ b/docs/component/dialog.md
@@ -351,8 +351,8 @@ const openOpenTypeDialog = () => {
 | confirmButtonProps | 确认按钮高级配置，支持传字符串、对象或 `null` | `DialogBoxButtonOption` | `{}` |
 | cancelButtonProps | 取消按钮高级配置，支持传字符串、对象或 `null` | `DialogBoxButtonOption` | 由 `showCancelButton` 推导 |
 | actions | 自定义操作按钮数组，配置后优先级高于确认/取消按钮 | `DialogAction[]` | - |
-| closeOnClickModal | 是否支持点击遮罩关闭（返回 action 为 `modal`） | `boolean` | `false` |
-| showClose | 是否显示右上角关闭按钮 | `boolean` | `false` |
+| closeOnClickModal | 是否支持点击遮罩关闭，触发 `fail` 回调，返回 `action` 为 `'modal'` | `boolean` | `false` |
+| showClose | 是否显示右上角关闭按钮，点击后触发 `fail` 回调，返回 `action` 为 `'close'` | `boolean` | `false` |
 | beforeConfirm | 确认前拦截函数，返回 `boolean` 或 `Promise<boolean>` | `DialogBeforeConfirm` | - |
 
 ## Attributes

--- a/docs/en-US/component/dialog.md
+++ b/docs/en-US/component/dialog.md
@@ -351,8 +351,8 @@ const openOpenTypeDialog = () => {
 | confirmButtonProps | Confirm button advanced configuration, supports passing string, object or `null` | `DialogBoxButtonOption` | `{}` |
 | cancelButtonProps | Cancel button advanced configuration, supports passing string, object or `null` | `DialogBoxButtonOption` | Derived from `showCancelButton` |
 | actions | Custom action button array, takes priority over confirm/cancel buttons after configuration | `DialogAction[]` | - |
-| closeOnClickModal | Whether to support clicking mask to close (returns action as `modal`) | `boolean` | `false` |
-| showClose | Whether to show top right close button | `boolean` | `false` |
+| closeOnClickModal | Whether clicking the mask closes the dialog, triggers `fail` callback with `action` as `'modal'` | `boolean` | `false` |
+| showClose | Whether to show the top-right close button, triggers `fail` callback with `action` as `'close'` | `boolean` | `false` |
 | beforeConfirm | Pre-confirm interception function, returns `boolean` or `Promise<boolean>` | `DialogBeforeConfirm` | - |
 
 ## Attributes

--- a/src/subPages/dialog/Index.vue
+++ b/src/subPages/dialog/Index.vue
@@ -613,11 +613,16 @@ function promptPasswordInput() {
 // ==================== 7. 交互功能 ====================
 
 function withCloseButton() {
-  dialog.confirm({
-    title: '系统公告',
-    msg: '系统将于今晚22:00进行维护升级',
-    showClose: true
-  })
+  dialog
+    .confirm({
+      title: '系统公告',
+      msg: '系统将于今晚22:00进行维护升级',
+      showClose: true,
+      closeOnClickModal: false
+    })
+    .catch((res) => {
+      toast.info(`关闭方式：${res.action}`)
+    })
 }
 
 function closeOnClickModal() {

--- a/src/uni_modules/wot-ui/components/wd-dialog/wd-dialog.vue
+++ b/src/uni_modules/wot-ui/components/wd-dialog/wd-dialog.vue
@@ -66,7 +66,7 @@
               v-for="(btn, index) in customActions"
               :key="index"
               v-bind="getActionButtonProps(btn)"
-              @click="handleAction(btn, index)"
+              @click="handleAction(btn)"
               @getuserinfo="(e: any) => handleOpenTypeEvent(btn, 'onGetuserinfo', e)"
               @contact="(e: any) => handleOpenTypeEvent(btn, 'onContact', e)"
               @getphonenumber="(e: any) => handleOpenTypeEvent(btn, 'onGetphonenumber', e)"
@@ -268,7 +268,7 @@ const textareaPropsWithoutModelValue = computed(() => {
 /**
  * 自定义 actions 按钮列表（当 theme 为 text 时强制 variant 为 text）
  */
-const customActions = computed(() => {
+const customActions = computed<DialogAction[]>(() => {
   if (!dialogState.actions || !dialogState.actions.length) return []
   return dialogState.actions.map((action) => {
     if (dialogState.theme === 'text') {
@@ -447,20 +447,15 @@ function toggleModal(action: 'confirm' | 'cancel' | 'modal' | 'close') {
  * @param action 按钮配置
  * @param index 索引
  */
-function handleAction(action: any, index: number) {
+function handleAction(action: DialogAction) {
   if (action.disabled || action.loading) return
 
-  // 如果提供了点击回调
   if (isFunction(action.click)) {
     action.click()
   }
 
-  // 默认关闭弹窗，除非显式指定不关闭（暂未支持 preventClose 属性，默认关闭）
-  // 也可以扩展：如果 click 返回 false，则不关闭
   handleConfirm({
-    action: 'confirm', // 或者新增 'action' 类型？但 Types 里 action 是必须的且枚举。
-    // 为了兼容，这里仍返回 confirm 或者是 context？
-    // 稍微 hack 一下，actions 场景下通常用户自己在 click 里处理了业务，这里主要是利用 confirm 回调来关闭
+    action: 'confirm',
     value: inputVal.value
   })
 }

--- a/src/uni_modules/wot-ui/components/wd-dialog/wd-dialog.vue
+++ b/src/uni_modules/wot-ui/components/wd-dialog/wd-dialog.vue
@@ -434,13 +434,9 @@ function toggleModal(action: 'confirm' | 'cancel' | 'modal' | 'close') {
       })
       break
     case 'modal':
+    case 'close':
       handleCancel({
-        action: 'modal'
-      })
-      break
-    default:
-      handleCancel({
-        action: 'close'
+        action: action
       })
       break
   }

--- a/src/uni_modules/wot-ui/components/wd-dialog/wd-dialog.vue
+++ b/src/uni_modules/wot-ui/components/wd-dialog/wd-dialog.vue
@@ -11,7 +11,7 @@
     :root-portal="rootPortal"
   >
     <view :class="rootClass">
-      <wd-icon v-if="dialogState.showClose" custom-class="wd-dialog__close" name="close" @click="toggleModal('modal')"></wd-icon>
+      <wd-icon v-if="dialogState.showClose" custom-class="wd-dialog__close" name="close" @click="toggleModal('close')"></wd-icon>
       <slot name="header" />
       <view :class="bodyClass">
         <slot name="image">
@@ -53,7 +53,7 @@
           </slot>
         </view>
       </view>
-      <slot name="actions" :confirm="() => toggleModal('confirm')" :cancel="() => toggleModal('cancel')" :close="() => toggleModal('modal')">
+      <slot name="actions" :confirm="() => toggleModal('confirm')" :cancel="() => toggleModal('cancel')" :close="() => toggleModal('close')">
         <view
           :class="`wd-dialog__actions ${dialogState.actionLayout === 'vertical' ? 'wd-dialog__actions--vertical' : ''} ${
             dialogState.actionLayout === 'vertical' || showCancelButton || (dialogState.actions && dialogState.actions.length > 1)
@@ -403,7 +403,7 @@ watch(
  * 点击操作
  * @param action
  */
-function toggleModal(action: 'confirm' | 'cancel' | 'modal') {
+function toggleModal(action: 'confirm' | 'cancel' | 'modal' | 'close') {
   if (action === 'modal' && !dialogState.closeOnClickModal) {
     return
   }
@@ -433,9 +433,14 @@ function toggleModal(action: 'confirm' | 'cancel' | 'modal') {
         action: action
       })
       break
-    default:
+    case 'modal':
       handleCancel({
         action: 'modal'
+      })
+      break
+    default:
+      handleCancel({
+        action: 'close'
       })
       break
   }

--- a/tests/components/wd-dialog.test.ts
+++ b/tests/components/wd-dialog.test.ts
@@ -73,6 +73,21 @@ describe('WdDialog', () => {
     expect((wrapper.vm as any).dialogState.show).toBe(true)
   })
 
+  test('closeOnClickModal 为 false 时 close 仍可关闭并返回 close action', async () => {
+    const wrapper = mount(WdDialog)
+    const fail = vi.fn()
+
+    ;(wrapper.vm as any).dialogState.show = true
+    ;(wrapper.vm as any).dialogState.showClose = true
+    ;(wrapper.vm as any).dialogState.closeOnClickModal = false
+    ;(wrapper.vm as any).dialogState.fail = fail
+
+    await (wrapper.vm as any).toggleModal('close')
+
+    expect(fail).toHaveBeenCalledWith({ action: 'close' })
+    expect((wrapper.vm as any).dialogState.show).toBe(false)
+  })
+
   test('closeOnClickModal 为 true 时点击遮罩触发 modal 关闭', async () => {
     const wrapper = mount(WdDialog)
     const fail = vi.fn()


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/wot-ui/wot-ui/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

**问题**

`wd-dialog` 在 `showClose: true` 场景下，右上角关闭按钮无法关闭弹框。

根因：关闭按钮与遮罩点击共用了同一个 `toggleModal('modal')` 入口，而该入口受 `closeOnClickModal` 控制——当 `closeOnClickModal` 为默认值 `false` 时，关闭按钮也会被一同拦截，导致点击无效。

**解决方案**

将"右上角关闭按钮关闭"与"点击遮罩关闭"拆分为两条独立语义链路：

- `modal`：仍仅表示点击遮罩关闭，继续受 `closeOnClickModal` 控制，触发 `fail` 回调，`result.action` 为 `'modal'`。
- `close`（新启用）：专属于右上角关闭按钮及 `actions` 插槽暴露的 `close` 方法，**不受 `closeOnClickModal` 控制**，触发 `fail` 回调，`result.action` 为 `'close'`。

**改动点**

| 文件 | 改动内容 |
|---|---|
| wd-dialog.vue | 关闭按钮 `@click` 从 `toggleModal('modal')` 改为 `toggleModal('close')`；`actions` 插槽 `close` 方法同步修改；`toggleModal` 函数新增 `close` 分支，直接调用 `handleCancel` |
| wd-dialog.test.ts | 新增回归用例：`closeOnClickModal=false` 时 `close` 仍可关闭且回调 `action` 为 `'close'` |
| dialog.md | 补充 `showClose` 与 `closeOnClickModal` 行为说明 |
| dialog.md | 同步英文文档 |

**用法示例**

```ts
dialog.confirm({
  title: '系统公告',
  msg: '系统将于今晚 22:00 进行维护',
  showClose: true,
  closeOnClickModal: false  // 遮罩不可关，close 按钮仍可关
}).catch((res) => {
  if (res.action === 'close') console.log('用户点击了关闭按钮')
  if (res.action === 'cancel') console.log('用户点击了取消')
})
```

此为非破坏性修改，旧代码行为不受影响；`ActionType` 类型中 `'close'` 已预先定义，本次为落地实现。 


<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **Documentation**
  * 更新对话框组件文档，澄清关闭交互的触发回调机制

* **Bug Fixes**
  * 区分对话框的两种关闭方式：点击模态背景和点击关闭按钮现返回不同的回调标识

* **Tests**
  * 新增单元测试验证关闭按钮交互的行为

<!-- end of auto-generated comment: release notes by coderabbit.ai -->