### PR TITLE
fix: 🐛 修复 ConfigProvider 中 Input 组件变量丢失的问题

### DIFF
--- a/scripts/buildThemeVars.ts
+++ b/scripts/buildThemeVars.ts
@@ -28,22 +28,46 @@ const parseScssVariableFields = (scssContent: string, captureComment: boolean) =
   const lines = scssContent.split('\n')
   const fields: ThemeVarField[] = []
   let pendingComment = ''
+  let statement = ''
+  let statementComment = ''
+
+  const parseStatement = (value: string, comment: string) => {
+    const variableMatch = value.match(/^\s*\$([A-Za-z0-9_-]+)\s*:\s*[\s\S]*?!default;\s*(?:\/\/\s*(.+))?\s*$/)
+    if (!variableMatch) return
+
+    const variableName = variableMatch[1]
+    const inlineComment = variableMatch[2] ? normalizeComment(variableMatch[2]) : ''
+    const fieldName = toCamelCase(variableName)
+    const fieldComment = captureComment ? inlineComment || comment : ''
+    fields.push({ fieldName, comment: fieldComment })
+  }
 
   lines.forEach((line) => {
+    if (statement) {
+      statement += `\n${line}`
+      if (line.includes(';')) {
+        parseStatement(statement, statementComment)
+        statement = ''
+        statementComment = ''
+      }
+      return
+    }
+
     const inlineCommentMatch = line.match(/^\s*\/\/\s*(.+)\s*$/)
     if (captureComment && inlineCommentMatch) {
       pendingComment = normalizeComment(inlineCommentMatch[1])
       return
     }
 
-    const variableMatch = line.match(/^\s*\$([A-Za-z0-9_-]+)\s*:\s*.*?!default;\s*(?:\/\/\s*(.+))?\s*$/)
-    if (variableMatch) {
-      const variableName = variableMatch[1]
-      const inlineComment = variableMatch[2] ? normalizeComment(variableMatch[2]) : ''
-      const fieldName = toCamelCase(variableName)
-      const comment = captureComment ? inlineComment || pendingComment : ''
-      fields.push({ fieldName, comment })
+    if (/^\s*\$[A-Za-z0-9_-]+\s*:/.test(line)) {
+      statement = line
+      statementComment = pendingComment
       pendingComment = ''
+      if (line.includes(';')) {
+        parseStatement(statement, statementComment)
+        statement = ''
+        statementComment = ''
+      }
       return
     }
 

--- a/scripts/buildThemeVars.ts
+++ b/scripts/buildThemeVars.ts
@@ -1,3 +1,4 @@
+/* eslint-disable quotes */
 import fs from 'fs'
 import path from 'path'
 
@@ -24,6 +25,49 @@ const toCamelCase = (value: string) => {
 
 const normalizeComment = (value: string) => value.replace(/\s+/g, ' ').trim()
 
+const hasStatementTerminator = (line: string) => {
+  let quote = ''
+  let escaped = false
+  let content = ''
+
+  for (let index = 0; index < line.length; index++) {
+    const char = line[index]
+    const nextChar = line[index + 1]
+
+    if (escaped) {
+      escaped = false
+      content += char
+      continue
+    }
+
+    if (char === '\\') {
+      escaped = true
+      content += char
+      continue
+    }
+
+    if (quote) {
+      if (char === quote) quote = ''
+      content += char
+      continue
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char
+      content += char
+      continue
+    }
+
+    if (char === '/' && nextChar === '/') {
+      break
+    }
+
+    content += char
+  }
+
+  return content.trimEnd().endsWith(';')
+}
+
 const parseScssVariableFields = (scssContent: string, captureComment: boolean) => {
   const lines = scssContent.split('\n')
   const fields: ThemeVarField[] = []
@@ -45,7 +89,7 @@ const parseScssVariableFields = (scssContent: string, captureComment: boolean) =
   lines.forEach((line) => {
     if (statement) {
       statement += `\n${line}`
-      if (line.includes(';')) {
+      if (hasStatementTerminator(line)) {
         parseStatement(statement, statementComment)
         statement = ''
         statementComment = ''
@@ -63,7 +107,7 @@ const parseScssVariableFields = (scssContent: string, captureComment: boolean) =
       statement = line
       statementComment = pendingComment
       pendingComment = ''
-      if (line.includes(';')) {
+      if (hasStatementTerminator(line)) {
         parseStatement(statement, statementComment)
         statement = ''
         statementComment = ''

--- a/src/uni_modules/wot-ui/components/wd-checkbox/index.scss
+++ b/src/uni_modules/wot-ui/components/wd-checkbox/index.scss
@@ -18,7 +18,7 @@ $checkbox-button-font-size: var(--wot-checkbox-button-font-size, $typography-bod
 $checkbox-button-line-height: var(--wot-checkbox-button-line-height, $typography-body-line-height-size-main) !default; // 按钮模式行高
 $checkbox-button-bg: var(--wot-checkbox-button-bg, $filled-bottom) !default; // 按钮模式背景颜色
 $checkbox-button-bg-checked: var(--wot-checkbox-button-bg-checked, $filled-oppo) !default; // 按钮模式选中状态背景颜色
-$checkbox-button-icon-size: var(--wot-checkbox-icon-size, $n-10) !default; // 按钮模式图标尺寸
+$checkbox-button-icon-size: var(--wot-checkbox-button-icon-size, $n-10) !default; // 按钮模式图标尺寸
 $checkbox-button-min-width: var(--wot-checkbox-button-min-width, calc(74 * #{$n-1})) !default; // 按钮模式最小宽
 $checkbox-button-max-width: var(--wot-checkbox-button-max-width, calc(148 * #{$n-1})) !default; // 按钮模式最大宽
 $checkbox-button-border-radius: var(--wot-checkbox-button-border-radius, $radius-main) !default; // 按钮圆角大小

--- a/src/uni_modules/wot-ui/components/wd-circle/index.scss
+++ b/src/uni_modules/wot-ui/components/wd-circle/index.scss
@@ -4,7 +4,7 @@
 // 圆环文字颜色
 $circle-text-color: var(--wot-circle-text-color, currentColor) !default;
 // 圆环文字字号
-$circle-text-font-size: var(--wot-circle-text-size, $typography-title-size-large) !default;
+$circle-text-font-size: var(--wot-circle-text-font-size, $typography-title-size-large) !default;
 // 圆环文字行高
 $circle-text-line-height: var(--wot-circle-text-line-height, $typography-title-line-height-size-large) !default;
 

--- a/src/uni_modules/wot-ui/components/wd-config-provider/types.ts
+++ b/src/uni_modules/wot-ui/components/wd-config-provider/types.ts
@@ -105,6 +105,7 @@ export type baseThemeVars = {
   fontWeightMedium?: string
   fontWeightRegular?: string
   fontWeightSemibold?: string
+  fontWeightThin?: string
   fontWeightUltraLight?: string
   grape1?: string
   grape10?: string
@@ -1138,6 +1139,24 @@ export type inputNumberThemeVars = {
   inputNumberInputWidth?: string // 输入框宽度
 }
 
+export type inputThemeVars = {
+  inputBg?: string // 输入框背景色
+  inputCountColor?: string // 输入框字数统计颜色
+  inputCountFontSize?: string // 输入框字数统计字号
+  inputCountLineHeight?: string // 输入框字数统计行高
+  inputCountMargin?: string // 输入框字数统计间距
+  inputDisabledColor?: string // 输入框禁用颜色
+  inputErrorColor?: string // 输入框错误颜色
+  inputIconColor?: string // 输入框图标颜色
+  inputIconFontSize?: string // 输入框图标字号
+  inputIconMargin?: string // 输入框图标间距
+  inputInnerColor?: string // 输入框文字颜色
+  inputInnerFontSize?: string // 输入框内字号
+  inputInnerHeight?: string // 输入框内高度
+  inputInnerPlaceholderColor?: string // 输入框占位符颜色
+  inputPadding?: string // 输入框内边距
+}
+
 export type keyboardThemeVars = {
   keyboardBg?: string // 键盘背景色
   keyboardCloseColor?: string // 关闭按钮文字颜色
@@ -1245,6 +1264,7 @@ export type notifyThemeVars = {
   notifyFloatingMarginHorizontal?: string // floating 变体左右间距
   notifyFloatingMarginVertical?: string // floating 变体上下间距
   notifyFloatingRadius?: string // floating 变体圆角
+  notifyFloatingShadow?: string // floating 变体阴影
   notifyFontSize?: string // 通知文字字号
   notifyIconSize?: string // 图标尺寸
   notifyIconSpacing?: string // 图标间距
@@ -1749,6 +1769,7 @@ export type tabbarThemeVars = {
   tabbarHeight?: string // 高度
   tabbarRoundMarginHorizontal?: string // round 变体水平外边距
   tabbarRoundRadius?: string // round 变体圆角
+  tabbarRoundShadow?: string // round 变体阴影
   tabbarZIndex?: string // 固定定位层级
 }
 
@@ -2027,6 +2048,7 @@ export type ConfigProviderThemeVars = baseThemeVars &
   indexAnchorThemeVars &
   indexBarThemeVars &
   inputNumberThemeVars &
+  inputThemeVars &
   keyboardThemeVars &
   loadingThemeVars &
   loadmoreThemeVars &

--- a/src/uni_modules/wot-ui/components/wd-input/index.scss
+++ b/src/uni_modules/wot-ui/components/wd-input/index.scss
@@ -1,5 +1,6 @@
 @use '../../styles/mixin/mixin.scss'as *;
 @use '../../styles/variable.scss'as *;
+
 // 输入框内边距
 $input-padding: var(--wot-input-padding, $padding-loose $padding-loose) !default;
 // 输入框背景色

--- a/src/uni_modules/wot-ui/components/wd-input/index.scss
+++ b/src/uni_modules/wot-ui/components/wd-input/index.scss
@@ -1,35 +1,35 @@
 @use '../../styles/mixin/mixin.scss'as *;
 @use '../../styles/variable.scss'as *;
 // 输入框内边距
-$input-padding: var(--wot-input-padding, $padding-loose $padding-loose);
+$input-padding: var(--wot-input-padding, $padding-loose $padding-loose) !default;
 // 输入框背景色
-$input-bg: var(--wot-input-bg, $filled-oppo);
+$input-bg: var(--wot-input-bg, $filled-oppo) !default;
 // 输入框内高度
-$input-inner-height: var(--wot-input-inner-height, $n-20);
+$input-inner-height: var(--wot-input-inner-height, $n-20) !default;
 // 输入框内字号
-$input-inner-font-size: var(--wot-input-inner-font-size, $typography-body-size-main);
+$input-inner-font-size: var(--wot-input-inner-font-size, $typography-body-size-main) !default;
 // 输入框文字颜色
-$input-inner-color: var(--wot-input-inner-color, $text-main);
+$input-inner-color: var(--wot-input-inner-color, $text-main) !default;
 // 输入框占位符颜色
-$input-inner-placeholder-color: var(--wot-input-inner-placeholder-color, $text-placeholder);
+$input-inner-placeholder-color: var(--wot-input-inner-placeholder-color, $text-placeholder) !default;
 // 输入框禁用颜色
-$input-disabled-color: var(--wot-input-disabled-color, $text-disabled);
+$input-disabled-color: var(--wot-input-disabled-color, $text-disabled) !default;
 // 输入框图标颜色
-$input-icon-color: var(--wot-input-icon-color, $icon-secondary);
+$input-icon-color: var(--wot-input-icon-color, $icon-secondary) !default;
 // 输入框图标字号
-$input-icon-font-size: var(--wot-input-icon-font-size, $n-18);
+$input-icon-font-size: var(--wot-input-icon-font-size, $n-18) !default;
 // 输入框图标间距
-$input-icon-margin: var(--wot-input-icon-margin, $spacing-tight);
+$input-icon-margin: var(--wot-input-icon-margin, $spacing-tight) !default;
 // 输入框字数统计间距
-$input-count-margin: var(--wot-input-count-margin, $spacing-extra-loose);
+$input-count-margin: var(--wot-input-count-margin, $spacing-extra-loose) !default;
 // 输入框字数统计颜色
-$input-count-color: var(--wot-input-count-color, $text-auxiliary);
+$input-count-color: var(--wot-input-count-color, $text-auxiliary) !default;
 // 输入框字数统计字号
-$input-count-font-size: var(--wot-input-count-font-size, $typography-body-size-main);
+$input-count-font-size: var(--wot-input-count-font-size, $typography-body-size-main) !default;
 // 输入框字数统计行高
-$input-count-line-height: var(--wot-input-count-line-height, $typography-body-line-height-size-main);
+$input-count-line-height: var(--wot-input-count-line-height, $typography-body-line-height-size-main) !default;
 // 输入框错误颜色
-$input-error-color: var(--wot-input-error-color, $danger-main);
+$input-error-color: var(--wot-input-error-color, $danger-main) !default;
 
 @include b(input) {
   position: relative;

--- a/src/uni_modules/wot-ui/components/wd-notify/index.scss
+++ b/src/uni_modules/wot-ui/components/wd-notify/index.scss
@@ -41,8 +41,7 @@ $notify-floating-margin-horizontal: var(--wot-notify-floating-margin-horizontal,
 // floating 变体上下间距
 $notify-floating-margin-vertical: var(--wot-notify-floating-margin-vertical, $spacing-loose) !default;
 // floating 变体阴影
-$notify-floating-shadow: var(--wot-notify-floating-shadow,
-  0 12px 48px 16px rgba(39, 43, 59, 0.03), 0 9px 28px 8px rgba(39, 43, 59, 0.05), 0 5px 12px 4px rgba(39, 43, 59, 0.06)) !default;
+$notify-floating-shadow: var(--wot-notify-floating-shadow, 0 12px 48px 16px rgba(39, 43, 59, 0.03), 0 9px 28px 8px rgba(39, 43, 59, 0.05), 0 5px 12px 4px rgba(39, 43, 59, 0.06)) !default;
 
 // 通知类型配置映射
 $notify-types: ("primary": ("bg": $notify-primary-bg,

--- a/src/uni_modules/wot-ui/styles/variable.scss
+++ b/src/uni_modules/wot-ui/styles/variable.scss
@@ -258,7 +258,7 @@ $n-full: var(--wot-n-full, 9999px) !default;
 
 /* 字重系列 */
 $font-weight-ultra-light: var(--wot-font-weight-ultra-light, 100) !default;
-$font-weight-thin: var(--wot-font-weight-thin, 200);
+$font-weight-thin: var(--wot-font-weight-thin, 200) !default;
 $font-weight-light: var(--wot-font-weight-light, 300) !default;
 $font-weight-regular: var(--wot-font-weight-regular, 400) !default;
 $font-weight-medium: var(--wot-font-weight-medium, 600) !default;


### PR DESCRIPTION
✅ Closes: #36

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [x] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

Closes #36

### 💡 需求背景和解决方案

修复 `ConfigProviderThemeVars` 类型生成时部分主题变量遗漏的问题。

问题原因主要有两类：

1. `buildThemeVars.ts` 原先只按单行 SCSS 变量声明解析，导致多行定义的主题变量无法被识别，例如阴影类变量。
2. 部分 SCSS 变量缺少 `!default`，或 SCSS 变量名与对应的 `--wot-*` CSS 变量名不一致，导致主题变量类型缺失或类型提示与实际生效变量不一致。

本次改动：

- 调整 `buildThemeVars.ts` 的 SCSS 变量解析逻辑，支持多行变量定义。
- 为 `wd-input` 组件主题变量补充 `!default`。
- 为 `$font-weight-thin` 补充 `!default`。
- 修正 `wd-checkbox`、`wd-circle` 中 SCSS 变量名与 CSS 变量名不一致的问题。
- 补齐 `ConfigProviderThemeVars` 中遗漏的类型字段，包括 `inputThemeVars`、`notifyFloatingShadow`、`tabbarRoundShadow`、`fontWeightThin` 等。

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 增强了主题变量的提取可靠性，支持多行SCSS变量声明的解析。
  * 扩展了配置提供者的主题变量类型定义，新增输入框相关的主题变量支持。
  * 优化了多个组件（复选框、圆形、输入框、通知）的主题变量和Sass变量配置，提高了样式自定义的灵活性。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wot-ui/wot-ui/pull/37)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->