### PR TITLE
fix: 🐛 修复 FormItem label 属性不生效

### DIFF
--- a/src/uni_modules/wot-ui/components/wd-form-item/wd-form-item.vue
+++ b/src/uni_modules/wot-ui/components/wd-form-item/wd-form-item.vue
@@ -4,6 +4,7 @@
     :custom-style="customStyle"
     :use-title-slot="!!$slots.title"
     :title="title"
+    :label="label"
     :title-width="formItemTitleWidth"
     :prefix-icon="prefixIcon"
     :icon-size="iconSize"

--- a/src/uni_modules/wot-ui/components/wd-form-item/wd-form-item.vue
+++ b/src/uni_modules/wot-ui/components/wd-form-item/wd-form-item.vue
@@ -30,6 +30,10 @@
       <slot name="title"></slot>
     </template>
 
+    <template #label v-if="$slots.label">
+      <slot name="label"></slot>
+    </template>
+
     <slot>
       <text v-if="showPlaceholder" class="wd-form-item__placeholder">{{ placeholder }}</text>
       <text v-else-if="isDef(value)">{{ value }}</text>

--- a/tests/components/wd-form-item.test.ts
+++ b/tests/components/wd-form-item.test.ts
@@ -30,8 +30,19 @@ describe('WdFormItem', () => {
       global: { components: globalComponents }
     })
 
-    expect(wrapper.find('.wd-cell__label').exists()).toBe(true)
-    expect(wrapper.find('.wd-cell__label').text()).toBe('请输入真实姓名')
+    const cell = wrapper.findComponent({ name: 'wd-cell' })
+    expect(cell.props('label')).toBe('请输入真实姓名')
+  })
+
+  test('label slot 覆盖默认描述信息', () => {
+    const wrapper = mount(WdFormItem, {
+      props: { title: '姓名', label: '请输入真实姓名' },
+      slots: { label: '<text class="custom-label">自定义描述</text>' },
+      global: { components: globalComponents }
+    })
+
+    expect(wrapper.find('.custom-label').exists()).toBe(true)
+    expect(wrapper.find('.custom-label').text()).toBe('自定义描述')
   })
 
   test('value prop 渲染值，不显示 placeholder', () => {

--- a/tests/components/wd-form-item.test.ts
+++ b/tests/components/wd-form-item.test.ts
@@ -24,6 +24,16 @@ describe('WdFormItem', () => {
     expect(wrapper.text()).toContain('姓名')
   })
 
+  test('label prop 渲染描述信息', () => {
+    const wrapper = mount(WdFormItem, {
+      props: { title: '姓名', label: '请输入真实姓名' },
+      global: { components: globalComponents }
+    })
+
+    expect(wrapper.find('.wd-cell__label').exists()).toBe(true)
+    expect(wrapper.find('.wd-cell__label').text()).toBe('请输入真实姓名')
+  })
+
   test('value prop 渲染值，不显示 placeholder', () => {
     const wrapper = mount(WdFormItem, {
       props: { value: '张三', placeholder: '请输入姓名' },


### PR DESCRIPTION
✅ Closes: #30

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

Closes #30

### 💡 需求背景和解决方案

修复 `FormItem` 的 `label` 属性不生效的问题。

`wd-form-item` 已经声明了 `label` 属性，但组件内部渲染 `wd-cell` 时没有将 `label` 透传下去，导致用户配置 `label` 后页面中无法展示描述信息。

本次改动：

- 在 `wd-form-item` 内部将 `label` 透传给 `wd-cell`。
- 新增单元测试，覆盖 `label` 属性渲染描述信息的场景。

最终用法保持不变：

```vue
<wd-form-item title="用户名" label="请输入真实用户名" />
```

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充