### PR TITLE
fix: 🐛 将 wd-tag 组件默认插槽内容的承载元素从 text 更改为 view

### DIFF
--- a/src/uni_modules/wot-ui/components/wd-tag/wd-tag.vue
+++ b/src/uni_modules/wot-ui/components/wd-tag/wd-tag.vue
@@ -22,9 +22,9 @@
       <slot name="icon" v-if="$slots.icon || icon">
         <wd-icon :name="icon" custom-class="wd-tag__icon" />
       </slot>
-      <text class="wd-tag__text" :style="textStyle" v-if="$slots.default">
+      <view class="wd-tag__text" :style="textStyle" v-if="$slots.default">
         <slot />
-      </text>
+      </view>
       <view class="wd-tag__close" v-if="closable" @click.stop="handleClose">
         <wd-icon name="close" custom-class="wd-tag__close-icon"></wd-icon>
       </view>

--- a/tests/components/wd-tag.test.ts
+++ b/tests/components/wd-tag.test.ts
@@ -22,6 +22,16 @@ describe('WdTag', () => {
     expect(wrapper.text()).toBe('标签')
   })
 
+  test('默认插槽内容使用 view 容器承载', () => {
+    const wrapper = mount(WdTag, {
+      slots: {
+        default: '标签'
+      }
+    })
+
+    expect(wrapper.find('.wd-tag__text').element.tagName).toBe('VIEW')
+  })
+
   // 测试不同类型
   test('不同类型渲染', () => {
     const types: TagType[] = ['default', 'primary', 'success', 'warning', 'danger']


### PR DESCRIPTION
✅ Closes: #25

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

Closes #25

### 💡 需求背景和解决方案

修复微信小程序中 `wd-tag` 默认插槽内容响应式渲染异常的问题。

在微信小程序平台下，`wd-tag` 默认插槽原本使用 `text` 组件作为内容容器，可能导致插槽中的响应式数据更新异常。由于该容器主要用于承载默认插槽内容和应用文字样式，并不依赖 `text` 组件特性，因此本次将默认插槽容器调整为 `view`。

本次改动：

- 将 `wd-tag` 默认插槽外层容器由 `text` 改为 `view`。
- 保留原有 `wd-tag__text` 类名和样式绑定，避免影响现有样式。
- 新增单元测试，确认默认插槽内容使用 `view` 容器承载。

最终用法保持不变：

```vue
<wd-tag>{{ tagText }}</wd-tag>
```

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 优化了标签组件默认内容的渲染方式，改进了在提供默认插槽内容时的显示效果。

* **Tests**
  * 新增单元测试，验证标签组件的渲染行为符合预期。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wot-ui/wot-ui/pull/39)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->