### PR TITLE
fix: 🐛 修复日期时间选择器在 ios26 微信小程序端区域选择切换时高度坍缩的问题

### DIFF
--- a/src/uni_modules/wot-ui/components/wd-datetime-picker/index.scss
+++ b/src/uni_modules/wot-ui/components/wd-datetime-picker/index.scss
@@ -57,6 +57,7 @@ $datetime-picker-range-separator-height: var(--wot-datetime-picker-range-separat
   }
 
   @include e(wraper) {
+    position: relative;
     padding-bottom: var(--window-bottom);
   }
 
@@ -121,13 +122,15 @@ $datetime-picker-range-separator-height: var(--wot-datetime-picker-range-separat
   }
 
   @include e(hidden) {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
     visibility: hidden;
-    overflow: hidden;
-    height: 0;
+    pointer-events: none;
   }
 
   @include e(show) {
     visibility: visible;
-    height: auto;
   }
 }


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/wot-ui/wot-ui/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

无

### 💡 需求背景和解决方案

**问题：**  
在 iOS 26 微信小程序中，`wd-datetime-picker` 区域选择模式下切换「开始时间 / 结束时间」Tab 后，`picker-view` 高度坍缩为 0，无法正常显示。

**根因：**  
原实现通过 `height: 0; overflow: hidden` 来隐藏非激活的 picker-view。`picker-view` 是微信小程序原生组件（Native Component），在 iOS 26 新 WebKit 中，父容器被设为 `height: 0` 时原生层感知到尺寸为 0 并坍缩；切换回来后原生组件重新布局计算失败，导致高度始终为 0。

**解决方案：**  
- 给 `__wraper` 增加 `position: relative` 作为定位上下文
- 将 `__hidden` 改为 `position: absolute; visibility: hidden; pointer-events: none`

隐藏态的 picker-view 始终保持渲染、始终持有正确的尺寸，原生层无需销毁重建，切换时直接显示即可，彻底规避 iOS 26 的布局重算 bug。

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 样式优化

* **样式**
  * 改进了日期时间选择器组件的显示和隐藏机制，优化了视觉呈现效果和性能表现。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wot-ui/wot-ui/pull/41)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->