### PR TITLE
fix: 🐛 兼容性修复与类型补全

### DIFF
--- a/scripts/buildThemeVars.ts
+++ b/scripts/buildThemeVars.ts
@@ -204,6 +204,7 @@ export const configProviderProps = {
 export type ConfigProviderProps = ExtractPropTypes<typeof configProviderProps>
 
 export type ConfigProviderProvide = {
+  theme: ComputedRef<string>
   themeStyle: ComputedRef<string>
 }
 

--- a/src/uni_modules/wot-ui/components/wd-avatar/wd-avatar.vue
+++ b/src/uni_modules/wot-ui/components/wd-avatar/wd-avatar.vue
@@ -136,7 +136,7 @@ const rootStyle = computed(() => {
     } else if (cascading === 'right-up') {
       // 右侧在上，越前面越大
       const maxCount = avatarGroup.value.props.maxCount
-      let count = avatarGroup.value.children?.length ?? 0
+      let count = avatarGroup.value.children ? avatarGroup.value.children.length : 0
 
       if (isDef(maxCount)) {
         const parsedCount = typeof maxCount === 'number' ? maxCount : parseInt(maxCount, 10)

--- a/src/uni_modules/wot-ui/components/wd-config-provider/types.ts
+++ b/src/uni_modules/wot-ui/components/wd-config-provider/types.ts
@@ -19,6 +19,7 @@ export const configProviderProps = {
 export type ConfigProviderProps = ExtractPropTypes<typeof configProviderProps>
 
 export type ConfigProviderProvide = {
+  theme: ComputedRef<string>
   themeStyle: ComputedRef<string>
 }
 

--- a/src/uni_modules/wot-ui/components/wd-picker-view/useSelection.ts
+++ b/src/uni_modules/wot-ui/components/wd-picker-view/useSelection.ts
@@ -108,7 +108,9 @@ export function useSelection(valueKey: string, labelKey: string, childrenKey: st
    * @returns {string[]} label数组
    */
   const selectedLabels = computed(() => {
-    return selectedIndex.value.map((row, col) => String(formatColumns.value[col][row][labelKey] ?? ''))
+    return selectedIndex.value.map((row, col) =>
+      String(isDef(formatColumns.value[col][row][labelKey]) ? formatColumns.value[col][row][labelKey] : '')
+    )
   })
 
   /**

--- a/src/uni_modules/wot-ui/components/wd-slider/wd-slider.vue
+++ b/src/uni_modules/wot-ui/components/wd-slider/wd-slider.vue
@@ -304,8 +304,24 @@ function initSlider() {
  */
 function getPointerPosition(event: any): number {
   return props.vertical
-    ? Number(event.detail?.y ?? event.clientY ?? event.touches?.[0]?.clientY ?? 0)
-    : Number(event.detail?.x ?? event.clientX ?? event.touches?.[0]?.clientX ?? 0)
+    ? Number(
+        isDef(event.detail?.y)
+          ? event.detail?.y
+          : isDef(event.clientY)
+          ? event.clientY
+          : isDef(event.touches?.[0]?.clientY)
+          ? event.touches?.[0]?.clientY
+          : 0
+      )
+    : Number(
+        isDef(event.detail?.x)
+          ? event.detail?.x
+          : isDef(event.clientX)
+          ? event.clientX
+          : isDef(event.touches?.[0]?.clientX)
+          ? event.touches?.[0]?.clientX
+          : 0
+      )
 }
 
 /**
@@ -413,7 +429,7 @@ function dotDisplayValue(index: number): number {
     return modelValue.value as number
   }
   const values = currentValue.value
-  return values[index] ?? values[0]
+  return isDef(values[index]) ? values[index] : values[0]
 }
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,16 +30,11 @@
       "@uni-helper/uni-types/volar-plugin"
     ]
   },
-  "include": [
-    "src/**/*.ts",
-    "src/**/*.vue",
-    "src/**/*.d.ts",
-    "tests/**/*.ts",
-    "components.d.ts"
-  ],
   "exclude": [
     "node_modules",
     "unpackage",
-    "src/**/*.nvue"
+    "src/**/*.nvue",
+    "docs",
+    "packages"
   ]
 }


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/wot-ui/wot-ui/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [x] TypeScript 定义更新
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

无

### 💡 需求背景和解决方案

**需求背景：**

部分小程序平台的 JS 引擎不支持空值合并运算符（`??`），导致组件运行时出现语法错误。同时 `ConfigProviderProvide` 类型定义缺少 `theme` 字段，与实际 `provide` 的数据不一致。`tsconfig.json` 中 `include` 配置范围较窄，未能覆盖 `scripts/` 等目录。

**解决方案：**

1. 将 `wd-avatar`、`wd-slider`、`wd-picker-view` 中的 `??` 替换为已有的 `isDef()` 工具函数三元表达式，语义等价且兼容性更好。
2. 在 `ConfigProviderProvide` 类型中补充 `theme: ComputedRef<string>` 字段，与 `wd-config-provider` 中 `linkChildren` 实际提供的数据保持一致。
3. 移除 `tsconfig.json` 的 `include` 配置，改用默认扫描，同时将 `docs` 和 `packages` 加入 `exclude`。

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 修复头像组层级级联逻辑
  * 优化选择器标签显示处理
  * 完善滑块坐标提取机制

* **新特性**
  * 配置提供器增强主题值支持

* **Chores**
  * 优化 TypeScript 编译配置

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wot-ui/wot-ui/pull/43)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->