### PR TITLE
fix: 🐛 修复 Tag 组件不传 type 时 size 样式被默认类型覆盖的问题

### DIFF
--- a/src/uni_modules/wot-ui/components/wd-tag/index.scss
+++ b/src/uni_modules/wot-ui/components/wd-tag/index.scss
@@ -181,6 +181,13 @@ $tag-types: (
 );
 
 $tag-sizes: (
+  "default": (
+    "font-size": $tag-default-font-size,
+    "line-height": $tag-default-line-height,
+    "padding": $tag-default-padding,
+    "round-padding": $tag-default-round-padding,
+    "icon-size": $tag-default-icon-size
+  ),
   "small": (
     "font-size": $tag-small-font-size,
     "line-height": $tag-small-line-height,
@@ -194,13 +201,6 @@ $tag-sizes: (
     "padding": $tag-medium-padding,
     "round-padding": $tag-medium-round-padding,
     "icon-size": $tag-medium-icon-size
-  ),
-  "default": (
-    "font-size": $tag-default-font-size,
-    "line-height": $tag-default-line-height,
-    "padding": $tag-default-padding,
-    "round-padding": $tag-default-round-padding,
-    "icon-size": $tag-default-icon-size
   ),
   "large": (
     "font-size": $tag-large-font-size,

--- a/src/uni_modules/wot-ui/components/wd-tag/index.scss
+++ b/src/uni_modules/wot-ui/components/wd-tag/index.scss
@@ -127,6 +127,7 @@ $tag-extra-large-round-padding: var(--wot-tag-extra-large-round-padding, $n-3 $p
 // 超大尺寸图标尺寸
 $tag-extra-large-icon-size: var(--wot-tag-extra-large-icon-size, $n-12) !default;
 
+// 这里的顺序决定了生成的 CSS 优先级，default 必须放在首位以确保其他尺寸可以覆盖它
 $tag-types: (
   "default": (
     "color": $tag-info-color,


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/wot-ui/wot-ui/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

暂无（来自社区反馈：`wd-tag` 在不传 `type` 时，`size="small"` 不生效）

### 💡 需求背景和解决方案

#### 问题描述
`wd-tag` 组件在不传 `type` prop（默认值为 `'default'`）时，`size="small"` / `size="medium"` 等尺寸样式不生效。

#### 根因分析
`index.scss` 中 `$tag-sizes` 的 map 顺序导致 `@each` 输出顺序为：`small -> medium -> default -> large -> extra-large`。  
因此 `.wd-tag.is-default` 的尺寸样式生成在 `.wd-tag.is-small` 之后，二者优先级相同，后者覆盖前者，最终表现为 small 样式被覆盖。

#### 解决方案
将 `$tag-sizes` 中 `"default"` 调整到首位，确保默认尺寸规则先输出，`small/medium/large/extra-large` 后输出并正确覆盖默认尺寸，避免 `type=default` 与 `size=*` 共存时的冲突。

#### 影响范围
仅调整 `wd-tag` 尺寸样式的生成顺序，不涉及 API 变更，不影响现有用法。

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **样式修复**
  * 修正了标签组件样式定义中的结构问题，确保各尺寸标签的样式声明清晰无误，显示效果更加一致。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wot-ui/wot-ui/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->