### PR TITLE
fix: 🐛 修复 size 属性在 image 和 cssIcon 模式下的无效问题

### DIFF
--- a/src/uni_modules/wot-ui/components/wd-icon/wd-icon.vue
+++ b/src/uni_modules/wot-ui/components/wd-icon/wd-icon.vue
@@ -61,8 +61,8 @@ const rootStyle = computed(() => {
   if (props.size) {
     const sizeValue = addUnit(props.size)
     style['font-size'] = sizeValue
-    // CSS 图标模式下，同步设置 width/height
-    if (props.cssIcon) {
+    // CSS 图标和图片模式下，同步设置 width/height
+    if (props.cssIcon || isImage.value) {
       style['width'] = sizeValue
       style['height'] = sizeValue
     }


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

无相关 Issue。

### 💡 需求背景和解决方案

1. **需求背景**：`wd-icon` 组件的 `size` 属性在 `image` 和 `cssIcon` 模式下未能正确生效，导致宽高无法动态调整。
2. **解决方案**：
   - 在 `wd-icon` 组件中添加内联样式以动态设置 `width` 和 `height`。
   - 替换 SCSS 中的默认值 `1em` 为更稳定的 `$icon-font-size`。
   - 更新 `icon` 组件的演示页面，添加验证 `size` 属性的示例。

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充