### PR TITLE
refactor: ♻️  为多个组件补齐模板中使用的子组件导入

### DIFF
--- a/src/uni_modules/wot-ui/components/wd-button/wd-button.vue
+++ b/src/uni_modules/wot-ui/components/wd-button/wd-button.vue
@@ -65,6 +65,7 @@ export default {
 
 <script lang="ts" setup>
 import wdIcon from '../wd-icon/wd-icon.vue'
+import wdLoading from '../wd-loading/wd-loading.vue'
 import { computed, useSlots } from 'vue'
 import { buttonProps } from './types'
 import { isDef, omitBy, isUndefined } from '../../common/util'

--- a/src/uni_modules/wot-ui/components/wd-calendar-view/monthPanel/month-panel.vue
+++ b/src/uni_modules/wot-ui/components/wd-calendar-view/monthPanel/month-panel.vue
@@ -102,6 +102,7 @@ export default {
 </script>
 
 <script lang="ts" setup>
+import wdIcon from '../../wd-icon/wd-icon.vue'
 import wdDatetimePickerView from '../../wd-datetime-picker-view/wd-datetime-picker-view.vue'
 import { computed, ref, watch, onMounted, type CSSProperties } from 'vue'
 import { debounce, isArray, isEqual, isNumber, pause, padZero, addUnit, objToStyle } from '../../../common/util'

--- a/src/uni_modules/wot-ui/components/wd-calendar-view/yearPanel/year-panel.vue
+++ b/src/uni_modules/wot-ui/components/wd-calendar-view/yearPanel/year-panel.vue
@@ -61,6 +61,7 @@ export default {
 </script>
 
 <script lang="ts" setup>
+import wdIcon from '../../wd-icon/wd-icon.vue'
 import { computed, ref, onMounted } from 'vue'
 import { compareYear, formatYearTitle, getYears } from '../utils'
 import { isArray, isNumber, pause } from '../../../common/util'

--- a/src/uni_modules/wot-ui/components/wd-dialog/wd-dialog.vue
+++ b/src/uni_modules/wot-ui/components/wd-dialog/wd-dialog.vue
@@ -136,6 +136,7 @@ export default {
 <script lang="ts" setup>
 import wdPopup from '../wd-popup/wd-popup.vue'
 import wdButton from '../wd-button/wd-button.vue'
+import wdIcon from '../wd-icon/wd-icon.vue'
 import wdInput from '../wd-input/wd-input.vue'
 import wdTextarea from '../wd-textarea/wd-textarea.vue'
 import { computed, inject, reactive, ref, watch } from 'vue'

--- a/src/uni_modules/wot-ui/components/wd-drop-menu/wd-drop-menu.vue
+++ b/src/uni_modules/wot-ui/components/wd-drop-menu/wd-drop-menu.vue
@@ -53,6 +53,7 @@ import { getRect, getSystemInfo, uuid } from '../../common/util'
 import { useChildren } from '../../composables/useChildren'
 import { DROP_MENU_KEY, dropMenuProps } from './types'
 import wdOverlay from '../wd-overlay/wd-overlay.vue'
+import wdIcon from '../wd-icon/wd-icon.vue'
 
 const props = defineProps(dropMenuProps)
 const queue = inject<Queue | null>(queueKey, null)

--- a/src/uni_modules/wot-ui/components/wd-img/wd-img.vue
+++ b/src/uni_modules/wot-ui/components/wd-img/wd-img.vue
@@ -36,6 +36,7 @@ export default {
 </script>
 
 <script lang="ts" setup>
+import wdIcon from '../wd-icon/wd-icon.vue'
 import { computed, ref } from 'vue'
 import { addUnit, isDef, objToStyle } from '../../common/util'
 import { imgProps } from './types'

--- a/src/uni_modules/wot-ui/components/wd-keyboard/key/index.vue
+++ b/src/uni_modules/wot-ui/components/wd-keyboard/key/index.vue
@@ -32,6 +32,8 @@ export default {
 </script>
 
 <script lang="ts" setup>
+import wdLoading from '../../wd-loading/wd-loading.vue'
+import wdIcon from '../../wd-icon/wd-icon.vue'
 import { computed, ref } from 'vue'
 import { useTouch } from '../../../composables/useTouch'
 import { keyProps } from './types'

--- a/src/uni_modules/wot-ui/components/wd-notify/wd-notify.vue
+++ b/src/uni_modules/wot-ui/components/wd-notify/wd-notify.vue
@@ -49,6 +49,7 @@ export default {
 
 <script lang="ts" setup>
 import wdPopup from '../wd-popup/wd-popup.vue'
+import wdIcon from '../wd-icon/wd-icon.vue'
 import { inject, computed, watch, ref, type CSSProperties } from 'vue'
 import { notifyProps, type NotifyProps } from './types'
 import { getNotifyOptionKey } from '.'

--- a/src/uni_modules/wot-ui/components/wd-select-picker/wd-select-picker.vue
+++ b/src/uni_modules/wot-ui/components/wd-select-picker/wd-select-picker.vue
@@ -109,6 +109,7 @@ import wdRadio from '../wd-radio/wd-radio.vue'
 import wdRadioGroup from '../wd-radio-group/wd-radio-group.vue'
 import wdButton from '../wd-button/wd-button.vue'
 import wdLoading from '../wd-loading/wd-loading.vue'
+import wdSearch from '../wd-search/wd-search.vue'
 
 import { getCurrentInstance, onBeforeMount, ref, watch, nextTick, computed } from 'vue'
 import { getRect, isArray, isDef, isFunction, pause } from '../../common/util'

--- a/src/uni_modules/wot-ui/components/wd-signature/wd-signature.vue
+++ b/src/uni_modules/wot-ui/components/wd-signature/wd-signature.vue
@@ -72,6 +72,7 @@ export default {
 }
 </script>
 <script lang="ts" setup>
+import wdButton from '../wd-button/wd-button.vue'
 import { computed, getCurrentInstance, onBeforeMount, onMounted, reactive, ref, watch, type CSSProperties } from 'vue'
 import { addUnit, getRect, getSystemInfo, isDef, objToStyle, uuid } from '../../common/util'
 import { signatureProps, type SignatureExpose, type SignatureResult, type Point, type Line } from './types'

--- a/src/uni_modules/wot-ui/components/wd-switch/wd-switch.vue
+++ b/src/uni_modules/wot-ui/components/wd-switch/wd-switch.vue
@@ -36,6 +36,8 @@ export default {
 </script>
 
 <script lang="ts" setup>
+import wdIcon from '../wd-icon/wd-icon.vue'
+import wdLoading from '../wd-loading/wd-loading.vue'
 import { computed, type CSSProperties, onBeforeMount } from 'vue'
 import { callInterceptor } from '../../common/interceptor'
 import { addUnit, isDef, isUndefined, objToStyle, omitBy } from '../../common/util'

--- a/src/uni_modules/wot-ui/components/wd-tabs/wd-tabs.vue
+++ b/src/uni_modules/wot-ui/components/wd-tabs/wd-tabs.vue
@@ -140,6 +140,7 @@ export default {
 </script>
 <script lang="ts" setup>
 import wdIcon from '../wd-icon/wd-icon.vue'
+import wdBadge from '../wd-badge/wd-badge.vue'
 import wdSticky from '../wd-sticky/wd-sticky.vue'
 import wdStickyBox from '../wd-sticky-box/wd-sticky-box.vue'
 import { computed, getCurrentInstance, onMounted, watch, nextTick, reactive, type CSSProperties, type ComponentInstance } from 'vue'


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [x] 其他改动（新增并优化 wd 组件导入一致性检查脚本）

### 🔗 相关 Issue

暂无直接关联 Issue。  
本次修改来源于组件中存在 `wd-*` 子组件在模板使用但未显式导入的问题排查与修复。

### 💡 需求背景和解决方案

需求背景：
1. 部分组件存在模板使用 `wd-*` 子组件但未在 `script setup` 中导入的情况，存在潜在运行/构建风险。
2. 需要提供可复用的自动检查手段，避免后续再次引入同类问题。

解决方案：
1. 批量补齐相关组件的缺失导入，确保模板使用与导入声明一致。
2. 新增并优化检查脚本 `check:wd-imports`，用于扫描组件内 `wd-*` 标签与组件导入是否匹配。
3. 脚本能力增强：
- 仅统计 `.vue` 组件导入，避免类型导入误判
- 支持识别 `WdXxx` 默认导入名映射到 `wd-xxx`
- 保留按路径兜底识别

验证结果：
1. `pnpm check:wd-imports` 通过（无缺失导入）。
2. `pnpm type-check` 通过。

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充（本次为代码修复与检查脚本增强，无对外 API 变更）
- [x] 代码演示已提供或无须提供（本次无演示交互变更）
- [x] TypeScript 定义已补充或无须补充（本次无 TS API 变更）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 修复了多个UI组件中缺失的子组件导入，确保模板内使用的组件能够正确解析和渲染。包括修复了按钮、图标、加载、徽章、搜索等组件在日历、对话框、下拉菜单、图片、键盘、通知、选择器、签名、开关和标签页等组件中的缺失导入问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->