### PR TITLE
fix: 🐛 修复 Cell 组件的 title 和 label 纯数字和英文场景不换行的问题

### DIFF
--- a/src/uni_modules/wot-ui/components/wd-cell/index.scss
+++ b/src/uni_modules/wot-ui/components/wd-cell/index.scss
@@ -121,6 +121,7 @@ $cell-border-margin-horizontal: var(--wot-cell-border-margin-horizontal, $spacin
   @include e(left) {
     position: relative;
     flex: 1;
+    min-width: 0;
     display: flex;
     text-align: left;
     font-size: $cell-title-font-size;
@@ -135,11 +136,13 @@ $cell-border-margin-horizontal: var(--wot-cell-border-margin-horizontal, $spacin
   }
 
   @include e(title) {
+    min-width: 0;
     font-size: $cell-title-font-size;
     line-height: $cell-title-line-height;
     color: $cell-title-color;
     white-space: normal;
-    word-break: break-all;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
   }
 
   @include e(required) {
@@ -160,7 +163,8 @@ $cell-border-margin-horizontal: var(--wot-cell-border-margin-horizontal, $spacin
     line-height: $cell-label-line-height;
     color: $cell-label-color;
     white-space: normal;
-    word-break: break-all;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
   }
 
   @include edeep(prefix) {
@@ -179,12 +183,14 @@ $cell-border-margin-horizontal: var(--wot-cell-border-margin-horizontal, $spacin
   @include e(value) {
     position: relative;
     flex: 1;
+    min-width: 0;
     font-size: $cell-value-font-size;
     line-height: $cell-value-line-height;
     color: $cell-value-color;
     vertical-align: middle;
     white-space: normal;
-    word-break: break-all;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
 
     @include m(left) {
       text-align: left;

--- a/src/uni_modules/wot-ui/components/wd-cell/index.scss
+++ b/src/uni_modules/wot-ui/components/wd-cell/index.scss
@@ -138,6 +138,8 @@ $cell-border-margin-horizontal: var(--wot-cell-border-margin-horizontal, $spacin
     font-size: $cell-title-font-size;
     line-height: $cell-title-line-height;
     color: $cell-title-color;
+    white-space: normal;
+    word-break: break-all;
   }
 
   @include e(required) {
@@ -157,6 +159,8 @@ $cell-border-margin-horizontal: var(--wot-cell-border-margin-horizontal, $spacin
     font-size: $cell-label-font-size;
     line-height: $cell-label-line-height;
     color: $cell-label-color;
+    white-space: normal;
+    word-break: break-all;
   }
 
   @include edeep(prefix) {
@@ -179,6 +183,7 @@ $cell-border-margin-horizontal: var(--wot-cell-border-margin-horizontal, $spacin
     line-height: $cell-value-line-height;
     color: $cell-value-color;
     vertical-align: middle;
+    white-space: normal;
     word-break: break-all;
 
     @include m(left) {


### PR DESCRIPTION
✅ Closes: #47

<!--
请务必阅读[贡献指南](https://github.com/wot-ui/wot-ui/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

- https://github.com/wot-ui/wot-ui/issues/47

### 💡 需求背景和解决方案

需求背景：
1. `wd-cell` 在部分场景下出现长文本不换行问题，用户需要额外在全局样式中手动覆盖，影响组件开箱即用体验。
2. 问题在 H5 场景可复现，Issue #47 已反馈对应现象。

解决方案：
1. 在 `wd-cell` 相关文本区域补充稳定换行样式，统一使用 `word-break: break-all;`。
2. 保持现有 API 不变，仅做样式层最小修复，不引入行为变更。

最终效果：
1. 无需业务侧额外全局样式兜底，`wd-cell` 长文本可在组件内正常换行。
2. 不影响现有 `ellipsis` 等能力的使用方式。

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充（本次为样式修复，无 API 变更）
- [x] 代码演示已提供或无须提供（本次无新增演示需求）
- [x] TypeScript 定义已补充或无须补充（本次无 TS 定义变更）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **样式优化**
  * 改进了单元格组件的文本换行与溢出处理：标题、标签和值现在使用更温和的换行策略并避免词内强制断行，能更好地展示长文本且减少溢出。
  * 调整了布局约束以改善弹性布局下的缩放与截断行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->