### PR TITLE
fix: 🐛 将 FAB 组件示例中的错误按钮类型更改为危险按钮

### DIFF
--- a/src/subPages/fab/Index.vue
+++ b/src/subPages/fab/Index.vue
@@ -7,7 +7,7 @@
             <wd-radio value="primary" custom-class="page-fab__radio">{{ $t('zhu-yao-an-niu') }}</wd-radio>
             <wd-radio value="success" custom-class="page-fab__radio">{{ $t('cheng-gong-an-niu-0') }}</wd-radio>
             <wd-radio value="warning" custom-class="page-fab__radio">{{ $t('jing-gao-an-niu-0') }}</wd-radio>
-            <wd-radio value="error" custom-class="page-fab__radio">{{ $t('wei-xian-an-niu') }}</wd-radio>
+            <wd-radio value="danger" custom-class="page-fab__radio">{{ $t('wei-xian-an-niu') }}</wd-radio>
             <wd-radio value="info" custom-class="page-fab__radio">{{ $t('xin-xi-an-niu') }}</wd-radio>
           </wd-radio-group>
         </demo-group-item>


### PR DESCRIPTION
✅ Closes: #5

<!--
请务必阅读[贡献指南](https://github.com/wot-ui/wot-ui/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

修复 Fab 悬浮按钮示例中危险按钮显示有误的问题。

### 💡 需求背景和解决方案

Fab 悬浮按钮示例中，“危险按钮”选项的值误写为 `error`，但 `wd-fab` 组件的 `type` 仅支持 `primary`、`success`、`info`、`warning`、`danger`。

因此选择“危险按钮”时，示例无法正确应用 `danger` 类型样式。

本次修复将示例中的 radio value 从 `error` 调整为 `danger`，与组件真实 API 保持一致。

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* FAB 组件中危险操作按钮的值已更新，以改进类型分类的准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->