### PR TITLE
docs: ✏️  补全 form-item 文档 value-align 属性

### DIFF
--- a/docs/component/form.md
+++ b/docs/component/form.md
@@ -1311,8 +1311,17 @@ function handleIconClick() {
 | label | 描述信息 | `string` | - |
 | clickable | 是否开启点击反馈 | `boolean` | `false` |
 | is-link | 是否展示右侧箭头并开启点击反馈 | `boolean` | `false` |
+| size | 单元格大小，可选值为 `large`，优先使用自身配置，未设置时继承 Form | `string` | - |
+| border | 是否展示边框线，优先使用自身配置，未设置时继承 Form | `boolean` | - |
+| title-width | 左侧标题宽度，优先使用自身配置，未设置时继承 Form | `string \| number` | `98px` |
+| center | 是否使内容垂直居中，优先使用自身配置，未设置时继承 Form | `boolean` | - |
 | required | 是否必填 | `boolean` | - |
 | validate-trigger | 校验触发时机，可选值为 `change`、`blur`、`submit` | `string \| string[]` | - |
+| layout | 单元格布局方式，可选值为 `horizontal`、`vertical`，优先使用自身配置，未设置时继承 Form | `string` | `horizontal` |
+| value-align | 右侧内容对齐方式，可选值为 `left`、`right`、`center`，优先使用自身配置，未设置时继承 Form | `string` | `left` |
+| ellipsis | 是否超出隐藏显示省略号，优先使用自身配置，未设置时继承 Form | `boolean` | - |
+| asterisk-position | 必填星号位置，可选值为 `start`、`end`，优先使用自身配置，未设置时继承 Form | `string` | `start` |
+| hide-asterisk | 是否隐藏必填星号，优先使用自身配置，未设置时继承 Form | `boolean` | - |
 
 ### FormSchema 数据结构
 

--- a/docs/en-US/component/form.md
+++ b/docs/en-US/component/form.md
@@ -781,8 +781,17 @@ All properties of this component, in addition to supporting specific form item c
 | label | Description information | `string` | - |
 | clickable | Whether to enable click feedback | `boolean` | `false` |
 | is-link | Whether to show right arrow and enable click feedback | `boolean` | `false` |
+| size | Cell size, optional value is `large`; uses its own configuration first, and inherits from Form when not set | `string` | - |
+| border | Whether to show border lines; uses its own configuration first, and inherits from Form when not set | `boolean` | - |
+| title-width | Left title width; uses its own configuration first, and inherits from Form when not set | `string \| number` | `98px` |
+| center | Whether to vertically center content; uses its own configuration first, and inherits from Form when not set | `boolean` | - |
 | required | Whether required | `boolean` | - |
 | validate-trigger | Validation trigger timing, optional values are `change`, `blur`, `submit` | `string \| string[]` | - |
+| layout | Cell layout method, optional values are `horizontal`, `vertical`; uses its own configuration first, and inherits from Form when not set | `string` | `horizontal` |
+| value-align | Right content alignment method, optional values are `left`, `right`, `center`; uses its own configuration first, and inherits from Form when not set | `string` | `left` |
+| ellipsis | Whether to hide overflow and show ellipsis; uses its own configuration first, and inherits from Form when not set | `boolean` | - |
+| asterisk-position | Required asterisk position, optional values are `start`, `end`; uses its own configuration first, and inherits from Form when not set | `string` | `start` |
+| hide-asterisk | Whether to hide required asterisk; uses its own configuration first, and inherits from Form when not set | `boolean` | - |
 
 ### FormSchema Data Structure
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "build:app-android": "uni build -p app-android",
     "build:app-ios": "uni build -p app-ios",
     "build:custom": "uni build -p",
+    "dev:mp-dingtalk": "uni -p mp-dingtalk",
     "build:h5": "uni build",
     "build:h5:ssr": "uni build --ssr",
     "build:mp-alipay": "uni build -p mp-alipay",

--- a/tests/components/wd-form-item.test.ts
+++ b/tests/components/wd-form-item.test.ts
@@ -297,7 +297,7 @@ describe('WdFormItem', () => {
     expect(cell.props('asteriskPosition')).toBe('start')
   })
 
-  test('form 的 value-align 会应用到 form-item 内容区域', () => {
+  test('form 的 value-align 会应用到 form-item 内容区域', async () => {
     const wrapper = mount(
       {
         template: `
@@ -311,6 +311,8 @@ describe('WdFormItem', () => {
       },
       { global: { components: globalComponents } }
     )
+
+    await nextTick()
 
     expect(wrapper.find('.wd-cell__value').classes()).toContain('wd-cell__value--right')
   })

--- a/tests/components/wd-form-item.test.ts
+++ b/tests/components/wd-form-item.test.ts
@@ -301,7 +301,7 @@ describe('WdFormItem', () => {
     const wrapper = mount(
       {
         template: `
-          <wd-form :model="formData" value-align="left">
+          <wd-form :model="formData" value-align="right">
             <wd-form-item title="姓名" value="张三" />
           </wd-form>
         `,
@@ -312,7 +312,7 @@ describe('WdFormItem', () => {
       { global: { components: globalComponents } }
     )
 
-    expect(wrapper.find('.wd-cell__value').classes()).toContain('wd-cell__value--left')
+    expect(wrapper.find('.wd-cell__value').classes()).toContain('wd-cell__value--right')
   })
 
   test('form-item 的 value-align 优先级高于 form', () => {

--- a/tests/components/wd-form-item.test.ts
+++ b/tests/components/wd-form-item.test.ts
@@ -297,6 +297,42 @@ describe('WdFormItem', () => {
     expect(cell.props('asteriskPosition')).toBe('start')
   })
 
+  test('form 的 value-align 会应用到 form-item 内容区域', () => {
+    const wrapper = mount(
+      {
+        template: `
+          <wd-form :model="formData" value-align="left">
+            <wd-form-item title="姓名" value="张三" />
+          </wd-form>
+        `,
+        data() {
+          return { formData: {} }
+        }
+      },
+      { global: { components: globalComponents } }
+    )
+
+    expect(wrapper.find('.wd-cell__value').classes()).toContain('wd-cell__value--left')
+  })
+
+  test('form-item 的 value-align 优先级高于 form', () => {
+    const wrapper = mount(
+      {
+        template: `
+          <wd-form :model="formData" value-align="left">
+            <wd-form-item title="姓名" value="张三" value-align="center" />
+          </wd-form>
+        `,
+        data() {
+          return { formData: {} }
+        }
+      },
+      { global: { components: globalComponents } }
+    )
+
+    expect(wrapper.find('.wd-cell__value').classes()).toContain('wd-cell__value--center')
+  })
+
   test('form-item 传入 border 时优先使用自身配置', () => {
     const wrapper = mount(WdFormItem, {
       props: { border: true },


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [x] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [x] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

关联 #53

### 💡 需求背景和解决方案

本次改动补全 `wd-form-item` 在 Form 文档中的属性说明。此前中英文文档的 `FormItem Attributes` 表只通过文案说明 `wd-form-item` 可继承 `Form` 的公共配置，但未逐项列出部分可直接配置在 `wd-form-item` 上的 props，容易让用户误以为这些属性只能配置在 `wd-form` 上。

本次补充了中英文文档中的 `FormItem Attributes`：

- `size`
- `border`
- `title-width`
- `center`
- `layout`
- `value-align`
- `ellipsis`
- `asterisk-position`
- `hide-asterisk`

同时说明这些属性在 `wd-form-item` 上会优先使用自身配置，未设置时再继承 `Form`，并补充了 `title-width`、`layout`、`value-align`、`asterisk-position` 的默认值。

另外补充了 `wd-form-item` 测试用例，覆盖：

- `wd-form` 上配置 `value-align` 后可应用到 `wd-form-item` 内容区域
- `wd-form-item` 自身配置 `value-align` 时优先级高于 `wd-form`

验证命令：

```bash
pnpm test:h5 --run tests/components/wd-form-item.test.ts -- --reporter=verbose

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Documentation**
  * 完善 FormItem 属性表，新增/补充多项配置及默认值与继承说明（如 size、border、title-width、layout、value-align、ellipsis、asterisk-position 等）

* **New Features**
  * 增加本地开发脚本以支持钉钉小程序调试

* **Tests**
  * 新增 value-align 继承与优先级相关测试，验证表单项对齐行为
<!-- end of auto-generated comment: release notes by coderabbit.ai -->