### PR TITLE
fix(docs): 修复v1 to v2 vite 插件自动导入问题

### DIFF
--- a/docs/guide/migration-v2.md
+++ b/docs/guide/migration-v2.md
@@ -220,7 +220,6 @@ export function WotResolver(): ComponentResolver {
       if (name.match(/^Wd[A-Z]/)) {
         const compName = kebabCase(name)
         return {
-          name,
           from: `@wot-ui/ui/components/${compName}/${compName}.vue`
         }
       }


### PR DESCRIPTION
移除name之前，生成结果
const WdCard: typeof import('@wot-ui/ui/components/wd-card/wd-card.vue')['WdCard']

移除name之后，生成结果
const WdCard: typeof import('@wot-ui/ui/components/wd-card/wd-card.vue')['default']


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 更新了迁移指南中的插件自动导入示例代码，简化了组件解析逻辑。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->