### PR TITLE
feat(button): ✨ 新增 subtle 类型变体

### DIFF
--- a/docs/component/button.md
+++ b/docs/component/button.md
@@ -58,6 +58,14 @@
 <wd-button variant="soft">主要按钮</wd-button>
 ```
 
+### 柔和描边
+
+设置 `variant="subtle"`。
+
+```html
+<wd-button variant="subtle">主要按钮</wd-button>
+```
+
 ### 文字
 
 设置 `variant="text"`。
@@ -148,7 +156,7 @@
 | 参数 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
 | type | 按钮类型，可选值为 `primary`、`success`、`info`、`warning`、`danger` | string | primary |
-| variant | 按钮变体，可选值为 `base`、`plain`、`dashed`、`soft`、`text` | string | base |
+| variant | 按钮变体，可选值为 `base`、`plain`、`dashed`、`soft`、`subtle`、`text` | string | base |
 | size | 按钮尺寸，可选值为 `mini`、`small`、`medium`、`large` | string | medium |
 | round | 圆角按钮 | boolean | false |
 | disabled | 禁用按钮 | boolean | false |

--- a/docs/en-US/component/button.md
+++ b/docs/en-US/component/button.md
@@ -58,6 +58,14 @@ Set `variant="soft"`.
 <wd-button variant="soft">Primary Button</wd-button>
 ```
 
+### Subtle
+
+Set `variant="subtle"`.
+
+```html
+<wd-button variant="subtle">Primary Button</wd-button>
+```
+
 ### Text
 
 Set `variant="text"`.
@@ -148,7 +156,7 @@ Set the `block` property.
 | Parameter | Description | Type | Default Value |
 | --- | --- | --- | --- |
 | type | Button type, optional values are `primary`, `success`, `info`, `warning`, `danger` | string | primary |
-| variant | Button variant, optional values are `base`, `plain`, `dashed`, `soft`, `text` | string | base |
+| variant | Button variant, optional values are `base`, `plain`, `dashed`, `soft`, `subtle`, `text` | string | base |
 | size | Button size, optional values are `mini`, `small`, `medium`, `large` | string | medium |
 | round | Round button | boolean | false |
 | disabled | Disabled button | boolean | false |

--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -1355,6 +1355,7 @@
   "rootportal-chuan-tou-ce-shi": "root-portal Penetration Test",
   "rootportal-title": "Root Portal",
   "rou-he": "Soft",
+  "rou-he-miao-bian": "Subtle",
   "ru-ding-dan-chu-yu-zan-ting-zhuang-tai-jin-ru-wo-de-ding-dan-ye-mian-zhao-dao-yao-qu-xiao-de-ding-dan-dian-ji-qu-xiao-ding-dan-an-niu-xuan-ze-ding-dan-qu-xiao-yuan-yin-hou-dian-ji-xia-yi-bu-ti-jiao-shen-qing-ji-ke": "If the order is in a suspended state, go to the \"My Orders\" page, find the order you want to cancel, and click the \"Cancel Order\" button; After selecting the reason for canceling the order, click \"Next\" to submit the application.",
   "ru-ding-dan-chu-yu-zan-ting-zhuang-tai-jin-ru-wo-de-ding-dan-ye-mian-zhao-dao-yao-qu-xiao-de-ding-dan-dian-ji-qu-xiao-ding-dan-an-niu-xuan-ze-ding-dan-qu-xiao-yuan-yin-hou-dian-ji-xia-yi-bu-ti-jiao-shen-qing-ji-ke-0": "If the order is in a suspended state, go to the \"My Orders\" page, find the order you want to cancel, and click the \"Cancel Order\" button; After selecting the reason for canceling the order, click \"Next\" to submit the application.",
   "ruan-jian-gong-cheng": "software engineering",

--- a/src/locale/zh-CN.json
+++ b/src/locale/zh-CN.json
@@ -1355,6 +1355,7 @@
   "rootportal-chuan-tou-ce-shi": "root-portal 穿透测试",
   "rootportal-title": "Root Portal 根节点传送门",
   "rou-he": "柔和",
+  "rou-he-miao-bian": "柔和描边",
   "ru-ding-dan-chu-yu-zan-ting-zhuang-tai-jin-ru-wo-de-ding-dan-ye-mian-zhao-dao-yao-qu-xiao-de-ding-dan-dian-ji-qu-xiao-ding-dan-an-niu-xuan-ze-ding-dan-qu-xiao-yuan-yin-hou-dian-ji-xia-yi-bu-ti-jiao-shen-qing-ji-ke": "如订单处于暂停状态，进入“我的订单”页面，找到要取消的订单，点击“取消订单”按钮；选择订单取消原因后，点击“下一步”提交申请即可。",
   "ru-ding-dan-chu-yu-zan-ting-zhuang-tai-jin-ru-wo-de-ding-dan-ye-mian-zhao-dao-yao-qu-xiao-de-ding-dan-dian-ji-qu-xiao-ding-dan-an-niu-xuan-ze-ding-dan-qu-xiao-yuan-yin-hou-dian-ji-xia-yi-bu-ti-jiao-shen-qing-ji-ke-0": "如订单处于暂停状态，进入“我的订单”页面，找到要取消的订单，点击“取消订单”按钮；选择订单取消原因后，点击“下一步”提交申请即可。",
   "ruan-jian-gong-cheng": "软件工程",

--- a/src/subPages/button/Index.vue
+++ b/src/subPages/button/Index.vue
@@ -148,6 +148,7 @@ const variantItems = computed<Array<{ title: string; variant: ButtonVariant }>>(
   { title: t('lou-kong'), variant: 'plain' },
   { title: t('xu-xian'), variant: 'dashed' },
   { title: t('rou-he'), variant: 'soft' },
+  { title: t('rou-he-miao-bian'), variant: 'subtle' },
   { title: t('wen-zi-10'), variant: 'text' }
 ])
 

--- a/src/uni_modules/wot-ui/components/wd-button/index.scss
+++ b/src/uni_modules/wot-ui/components/wd-button/index.scss
@@ -275,6 +275,7 @@ $button-variants: (
   "plain": ("show-border": true),
   "dashed": ("show-border": true, "border-style": dashed),
   "soft": ("hide-border": true, "soft-bg": true),
+  "subtle": ("show-border": true, "soft-bg": true),
   "text": ("hide-border": true)
 );
 

--- a/src/uni_modules/wot-ui/components/wd-button/types.ts
+++ b/src/uni_modules/wot-ui/components/wd-button/types.ts
@@ -9,9 +9,9 @@ import { type LoadingProps } from '../wd-loading/types'
 export type ButtonType = 'primary' | 'success' | 'info' | 'warning' | 'danger'
 /**
  * 按钮变体
- * 可选值: 'base' | 'plain' | 'dashed' | 'soft' | 'text'
+ * 可选值: 'base' | 'plain' | 'dashed' | 'soft' | 'subtle' | 'text'
  */
-export type ButtonVariant = 'base' | 'plain' | 'dashed' | 'soft' | 'text'
+export type ButtonVariant = 'base' | 'plain' | 'dashed' | 'soft' | 'subtle' | 'text'
 /**
  * 按钮尺寸
  * 可选值: 'mini' | 'small' | 'medium' | 'large'
@@ -204,7 +204,7 @@ export const buttonProps = {
   /**
    * 按钮变体
    * 类型: ButtonVariant
-   * 可选值: 'base' | 'plain' | 'dashed' | 'soft' | 'text'
+   * 可选值: 'base' | 'plain' | 'dashed' | 'soft' | 'subtle' | 'text'
    * 不传则继承全局配置
    */
   variant: String as PropType<ButtonVariant>

--- a/tests/components/wd-button.test.ts
+++ b/tests/components/wd-button.test.ts
@@ -512,7 +512,7 @@ describe('WdButton', () => {
 
   // 测试按钮变体
   test('不同按钮变体', () => {
-    const variants: ButtonVariant[] = ['plain', 'dashed', 'text', 'base']
+    const variants: ButtonVariant[] = ['plain', 'dashed', 'soft', 'subtle', 'text', 'base']
 
     variants.forEach((variant) => {
       const wrapper = mount(WdButton, {


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/wot-ui/wot-ui/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [x] 站点、文档改进
- [x] 演示代码改进
- [x] 组件样式/交互改进
- [x] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 💡 需求背景和解决方案

新增 `subtle` 类型变体

<img width="300" alt="image" src="https://github.com/user-attachments/assets/9fe6c4b7-4384-40bb-ae32-96fc40813af4" />

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 按钮组件新增"柔和描边"变体，提供带边框的柔和背景样式选项。

* **文档**
  * 更新中英文组件文档，添加新变体的说明和使用示例。
  * 补充新变体在属性说明中的选项列表。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->