### PR TITLE
fix: 🐛 修复支付宝小程序 tabs 子组件渲染顺序错误的问题

### DIFF
--- a/src/uni_modules/wot-ui/composables/useChildren.ts
+++ b/src/uni_modules/wot-ui/composables/useChildren.ts
@@ -80,14 +80,8 @@ export function useChildren<
     const link = (child: ComponentInternalInstance) => {
       if (child.proxy) {
         if (internalChildren.indexOf(child) === -1) {
-          // #ifdef MP-ALIPAY
-          internalChildren.unshift(child)
-          publicChildren.unshift(child.proxy as Child)
-          // #endif
-          // #ifndef MP-ALIPAY
           internalChildren.push(child)
           publicChildren.push(child.proxy as Child)
-          // #endif
           sortChildren(parent, publicChildren, internalChildren)
         }
       }

--- a/tests/components/wd-tabs.test.ts
+++ b/tests/components/wd-tabs.test.ts
@@ -47,13 +47,11 @@ describe('WdTabs 和 WdTab 组件', () => {
     await nextTick()
 
     // 检查标签页导航是否正确渲染
-    // 测试环境中 virtualHost 导致每个 tab 注册两次，nav-item 数量为实际 tab 数 × 2
     const navItems = wrapper.findAll('.wd-tabs__nav-item')
-    expect(navItems.length).toBe(6)
-    // 每两个相邻 navItem 属于同一个 tab，奇偶对应同一 tab
+    expect(navItems.length).toBe(3)
     expect(navItems[0].find('.wd-tabs__nav-item-text').text()).toBe('标签1')
-    expect(navItems[2].find('.wd-tabs__nav-item-text').text()).toBe('标签2')
-    expect(navItems[4].find('.wd-tabs__nav-item-text').text()).toBe('标签3')
+    expect(navItems[1].find('.wd-tabs__nav-item-text').text()).toBe('标签2')
+    expect(navItems[2].find('.wd-tabs__nav-item-text').text()).toBe('标签3')
 
     // 检查第一个标签是否默认激活
     expect(navItems[0].classes()).toContain('is-active')
@@ -88,14 +86,14 @@ describe('WdTabs 和 WdTab 组件', () => {
 
     await nextTick()
 
-    // 点击第二个标签（索引2，因为每个 tab 对应两个 navItem）
+    // 点击第二个标签
     const navItems = wrapper.findAll('.wd-tabs__nav-item')
-    await navItems[2].trigger('click')
-    // 检查 change 事件是否被触发（doubled children 导致 index=2 而非 1）
-    expect(onChange).toHaveBeenCalledWith({ index: 2, name: 2 })
+    await navItems[1].trigger('click')
+    // 检查 change 事件是否被触发
+    expect(onChange).toHaveBeenCalledWith({ index: 1, name: 1 })
     await pause(50)
     // 检查第二个标签是否被激活
-    expect(navItems[2].classes()).toContain('is-active')
+    expect(navItems[1].classes()).toContain('is-active')
   })
 
   // 测试禁用标签
@@ -127,12 +125,12 @@ describe('WdTabs 和 WdTab 组件', () => {
 
     await nextTick()
 
-    // 检查禁用标签的样式（索引2，因为每个 tab 对应两个 navItem）
+    // 检查禁用标签的样式
     const navItems = wrapper.findAll('.wd-tabs__nav-item')
-    expect(navItems[2].classes()).toContain('is-disabled')
+    expect(navItems[1].classes()).toContain('is-disabled')
 
     // 点击禁用的标签
-    await navItems[2].trigger('click')
+    await navItems[1].trigger('click')
 
     // 检查 change 事件是否未被触发
     expect(onChange).not.toHaveBeenCalled()
@@ -175,8 +173,8 @@ describe('WdTabs 和 WdTab 组件', () => {
     await pause(150) // setActive 使用了 debounce(100ms)，需要等待
     await nextTick()
 
-    // 检查第二个标签是否被激活（索引2，因为每个 tab 对应两个 navItem）
-    expect(navItems[2].classes()).toContain('is-active')
+    // 检查第二个标签是否被激活
+    expect(navItems[1].classes()).toContain('is-active')
   })
 
   // 测试带图标的标签
@@ -202,7 +200,7 @@ describe('WdTabs 和 WdTab 组件', () => {
 
     // 由于图标在 WdTabs 组件中渲染，检查导航项是否正确渲染
     const navItems = wrapper.findAll('.wd-tabs__nav-item')
-    expect(navItems.length).toBe(4) // 2 tabs × 2
+    expect(navItems.length).toBe(2)
     expect(wrapper.find('.wd-tabs').exists()).toBe(true)
   })
 
@@ -228,9 +226,8 @@ describe('WdTabs 和 WdTab 组件', () => {
     await nextTick()
 
     // 由于 WdBadge 组件在测试环境中可能无法正确渲染
-    // 测试环境中 virtualHost 导致 navItem 数量为实际 tab 数 × 2
     const navItems = wrapper.findAll('.wd-tabs__nav-item')
-    expect(navItems.length).toBe(4)
+    expect(navItems.length).toBe(2)
     // 通过 nav-item-text 子元素取标题文字，避免徽标数字混入
     expect(navItems[0].find('.wd-tabs__nav-item-text').text()).toBe('标签1')
   })
@@ -335,12 +332,12 @@ describe('WdTabs 和 WdTab 组件', () => {
     await nextTick()
 
     // lazy=false 的标签初始就渲染内容（即使未激活），通过 textContent 可见
-    // 测试环境中 index 因 doubled children 偏移，使用 wrapper.text() 检查渲染
+    // 使用 wrapper.text() 检查渲染
     expect(wrapper.text()).toContain('内容3')
     // lazy=true（默认）的未激活 tab 不渲染内容（shouldBeRender=false）
     expect(wrapper.text()).not.toContain('内容2')
 
-    // 切换到第三个标签（doubled: index 4）
+    // 切换到第三个标签
     await wrapper.setData({ activeTab: 2 })
     await nextTick()
 
@@ -402,9 +399,8 @@ describe('WdTabs 和 WdTab 组件', () => {
     await nextTick()
 
     const items = wrapper.findAll('.wd-tabs__nav-item-text')
-    // 测试环境中每个 tab 对应两个 navItem，共 3×2=6 个；但 v-for 动态更新后可能有额外项
-    // 可能有旧 tab 残留（key 变化），故验证 >= 6 个并按步长 2 取唯一 tab 文本
-    expect(items.length).toBeGreaterThanOrEqual(6)
+    // v-for 动态更新后应包含 3 个 tab 文本
+    expect(items.length).toBe(3)
     // 找出包含 'Wot'/'Design'/'Uni' 的项，验证这 3 个标题存在且顺序正确
     const texts = items.map((i) => i.text())
     expect(texts).toContain('Wot')


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/wot-ui/wot-ui/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [x] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

用户反馈支付宝小程序在 component2 模式下子组件初始化顺序为正序，导致 Tab 组件显示顺序错误。

### 💡 需求背景和解决方案

**问题描述**：
- 原代码通过条件编译 `#ifdef MP-ALIPAY` 使用 `unshift()` 反序收集支付宝小程序的子组件，假设 component2 模式下子组件初始化是反序的
- 用户反馈实际 component2 子组件初始化已改为正序，导致 Tab 等组件显示顺序错误

**解决方案**：
- 移除支付宝特定的 `unshift()` 逻辑及相关条件编译指令
- 统一为 `push()` 逻辑，按正序收集所有平台的子组件
- 简化 `useChildren` 组合式 API，消除平台特定代码

**涉及改动**：
- `src/uni_modules/wot-ui/composables/useChildren.ts`：移除 `#ifdef MP-ALIPAY` 分支，统一为 push()
- `tests/components/wd-tabs.test.ts`：更新测试期望值，适配新的单份子项行为（原 ×2 现象消失）

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充（底层改动，无公开 API 变化，无须补充）
- [x] 代码演示已提供或无须提供（无须提供，这是内部实现改动）
- [x] TypeScript 定义已补充或无须补充（无须补充，没有类型变化）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修正了标签项新增后的排列方式，避免部分平台下顺序不一致的问题。
  * 优化了 Tabs 相关交互验证，确保切换、禁用、图标、徽标和懒加载场景下的表现更稳定。
* **Tests**
  * 更新了 Tabs 组件测试断言，使其按实际标签数量和索引进行校验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->