### PR TITLE
fix: 🐛 修复 Toast 组件图标设置图标大小后行高异常的问题

### DIFF
--- a/src/uni_modules/wot-ui/components/wd-toast/index.scss
+++ b/src/uni_modules/wot-ui/components/wd-toast/index.scss
@@ -54,7 +54,6 @@ $toast-loading-margin-bottom: var(--wot-toast-loading-margin-bottom, $spacing-ex
 
   @include edeep(icon) {
     font-size: $toast-icon-size;
-    line-height: $toast-icon-size;
     @include when(vertical) {
       margin-bottom: $toast-icon-margin-bottom;
     }


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/wot-ui/wot-ui/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

修复 wd-toast 在使用非 loading 图标时，icon-size 传入较大值后图标高度没有正常撑开的问题。之前 toast 样式层对图标额外设置了固定行高，导致图标虽然字号变大了，但实际占位高度仍停留在默认值，出现了 50px 图标但高度只有 24px 的割裂效果。

本次调整移除了 toast 层对图标的固定行高约束，让图标尺寸由 wd-icon 自身规则控制，确保 success、warning、info、error 等图标在设置较大尺寸时也能正常撑开，与 loading 图标的表现保持一致。



### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了 Toast 组件图标在竖向布局下的间距表现，图标下方留白更自然。
  * 调整了图标样式，避免其高度与行高设置带来的显示偏差。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->