### PR TITLE
feat: ✨ 修复 Form 表单同字段多条校验错误提示被覆盖问题

### DIFF
--- a/src/uni_modules/wot-ui/components/wd-form/wd-form.vue
+++ b/src/uni_modules/wot-ui/components/wd-form/wd-form.vue
@@ -97,7 +97,7 @@ function showMessage(errors: ErrorMessage[]) {
   const childrenProps = getChildrenProps()
   const messages = errors.reduce<ErrorMessage[]>((result, error) => {
     const matchedProp = getMatchedChildProp(error.prop, childrenProps)
-    if (error.message && matchedProp) {
+    if (error.message && matchedProp && !result.some((message) => message.prop === matchedProp)) {
       result.push({
         prop: matchedProp,
         message: error.message

--- a/tests/components/wd-form.test.ts
+++ b/tests/components/wd-form.test.ts
@@ -7,7 +7,7 @@ import WdFormItem from '@/uni_modules/wot-ui/components/wd-form-item/wd-form-ite
 import WdInput from '@/uni_modules/wot-ui/components/wd-input/wd-input.vue'
 import WdCell from '@/uni_modules/wot-ui/components/wd-cell/wd-cell.vue'
 import { zodAdapter } from '@/uni_modules/wot-ui/components/wd-form/adapters/zod'
-import type { FormSchema } from '@/uni_modules/wot-ui/components/wd-form/types'
+import type { ErrorMessage, FormSchema } from '@/uni_modules/wot-ui/components/wd-form/types'
 
 const globalComponents = {
   WdForm,
@@ -56,6 +56,43 @@ describe('WdForm schema validate', () => {
     const result = await form.vm.validate()
     expect(result.valid).toBe(false)
     expect(result.errors.length).toBe(2)
+  })
+
+  test('同一字段存在多条 zod 错误时展示首条错误', async () => {
+    const schema = zodAdapter(
+      z.object({
+        phone: z
+          .string()
+          .min(1, '请输入手机号')
+          .regex(/^1[3-9]\d{9}$/, '手机号格式不正确')
+      })
+    )
+    const wrapper = mount(
+      {
+        template: `
+          <wd-form ref="form" :model="formData" :schema="schema">
+            <wd-form-item prop="phone" title="手机号">
+              <wd-input v-model="formData.phone" />
+            </wd-form-item>
+          </wd-form>
+        `,
+        data() {
+          return {
+            formData: { phone: '' },
+            schema
+          }
+        }
+      },
+      { global: { components: globalComponents } }
+    )
+    const form = wrapper.findComponent({ ref: 'form' })
+
+    const result = await form.vm.validate()
+    await nextTick()
+
+    expect(result.valid).toBe(false)
+    expect(result.errors.map((error: ErrorMessage) => error.message)).toEqual(['请输入手机号', '手机号格式不正确'])
+    expect(wrapper.find('.wd-form-item__error-message').text()).toBe('请输入手机号')
   })
 
   test('支持指定字段校验', async () => {


### PR DESCRIPTION
✅ Closes: #89

<!--
请务必阅读[贡献指南](https://github.com/wot-ui/wot-ui/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

Closes #89

### 💡 需求背景和解决方案

修复 `wd-form` 在同一表单项存在多条校验错误时，后续错误提示覆盖首条错误提示的问题。

例如以下 zod 链式校验：

```ts
phone: z.string().min(1, '请输入手机号').regex(/^1[3-9]\d{9}$/, '手机号格式不正确')

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化表单错误收集逻辑，避免同一字段的错误信息重复显示。
  * 当同一字段存在多条校验错误时，验证结果仍会保留全部错误，界面只展示该字段的首条错误信息。
* **Tests**
  * 新增相关校验场景测试，覆盖同字段多错误与展示规则。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->