### PR TITLE
feat: ✨ 支持 Collapse 非受控模式

### DIFF
--- a/docs/component/collapse.md
+++ b/docs/component/collapse.md
@@ -6,7 +6,7 @@
 
 ### 基本使用
 
-`v-model` 绑定值可为：
+`v-model` 用于受控展开状态，不绑定时组件会自行维护展开状态。绑定值可为：
 - 普通折叠：`string[]`
 - 手风琴模式：`string`
 - 查看更多模式：`boolean`
@@ -52,6 +52,17 @@ const beforeExpend = (name: string) => {
 ```
 
 ## 组件变体
+
+### 非受控模式
+
+不传 `v-model` 时，组件会在内部维护展开状态，适用于只需要本地展开/收起、不关心当前展开值的场景。
+
+```html
+<wd-collapse>
+  <wd-collapse-item title="标签1" name="item1">这是一条简单的示例文字。</wd-collapse-item>
+  <wd-collapse-item title="标签2" name="item2">这是一条简单的示例文字。</wd-collapse-item>
+</wd-collapse>
+```
 
 ### 手风琴
 
@@ -166,7 +177,7 @@ collapseRef.value?.toggleAll({ expanded: true, skipDisabled: true })
 
 | 参数 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
-| v-model | 绑定值。普通模式为 `string[]`，手风琴模式为 `string`，查看更多模式为 `boolean` | `string \| string[] \| boolean` | - |
+| v-model | 绑定值，不传时组件内部维护展开状态。普通模式为 `string[]`，手风琴模式为 `string`，查看更多模式为 `boolean` | `string \| string[] \| boolean` | - |
 | accordion | 是否开启手风琴模式 | boolean | false |
 | viewmore | 是否开启查看更多模式 | boolean | false |
 | use-more-slot | 查看更多模式下是否启用 `more` 插槽 | boolean | false |

--- a/docs/component/collapse.md
+++ b/docs/component/collapse.md
@@ -11,6 +11,8 @@
 - 手风琴模式：`string`
 - 查看更多模式：`boolean`
 
+绑定 `v-model` 时请提供对应模式的初始值；如果初始值为 `undefined`，组件会按非受控模式处理。
+
 ```html
 <wd-collapse v-model="value">
   <wd-collapse-item title="标签1" name="item1">这是一条简单的示例文字。</wd-collapse-item>

--- a/docs/en-US/component/collapse.md
+++ b/docs/en-US/component/collapse.md
@@ -11,6 +11,8 @@ Place a set of content in multiple collapsible panels, click panel title to expa
 - Accordion mode: `string`
 - View more mode: `boolean`
 
+When binding `v-model`, provide an initial value that matches the current mode. If the initial value is `undefined`, the component treats it as uncontrolled mode.
+
 ```html
 <wd-collapse v-model="value">
   <wd-collapse-item title="Tag 1" name="item1">This is a simple example text.</wd-collapse-item>

--- a/docs/en-US/component/collapse.md
+++ b/docs/en-US/component/collapse.md
@@ -6,7 +6,7 @@ Place a set of content in multiple collapsible panels, click panel title to expa
 
 ### Basic Usage
 
-`v-model` binding value can be:
+`v-model` is used for controlled expand state. If it is not bound, the component maintains the expand state internally. The binding value can be:
 - Normal collapse: `string[]`
 - Accordion mode: `string`
 - View more mode: `boolean`
@@ -52,6 +52,17 @@ const beforeExpend = (name: string) => {
 ```
 
 ## Component Variant
+
+### Uncontrolled Mode
+
+When `v-model` is omitted, the component maintains the expand state internally. This is useful when you only need local expand/collapse behavior and do not need the current expanded value.
+
+```html
+<wd-collapse>
+  <wd-collapse-item title="Tag 1" name="item1">This is a simple example text.</wd-collapse-item>
+  <wd-collapse-item title="Tag 2" name="item2">This is a simple example text.</wd-collapse-item>
+</wd-collapse>
+```
 
 ### Accordion
 
@@ -166,7 +177,7 @@ collapseRef.value?.toggleAll({ expanded: true, skipDisabled: true })
 
 | Parameter | Description | Type | Default Value |
 | --- | --- | --- | --- |
-| v-model | Binding value. Normal mode is `string[]`, accordion mode is `string`, view more mode is `boolean` | `string \| string[] \| boolean` | - |
+| v-model | Binding value. If omitted, the component maintains the expand state internally. Normal mode is `string[]`, accordion mode is `string`, view more mode is `boolean` | `string \| string[] \| boolean` | - |
 | accordion | Whether to enable accordion mode | boolean | false |
 | viewmore | Whether to enable view more mode | boolean | false |
 | use-more-slot | Whether to enable `more` slot in view more mode | boolean | false |

--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -608,6 +608,7 @@
   "fang-xing": "Square",
   "fei-li-ji-geng-xin-mo-shi": "Non-immediate update mode",
   "fei-li-ji-geng-xin-mo-shi-zhi-notimmediate": "Non-immediate update mode - value: {0}",
+  "fei-shou-kong-mo-shi": "Uncontrolled mode",
   "fei-xuan-zhong-jin-yong": "Non selected disabled",
   "fei-yun-xu-kong-zhi-dan-ke-lin-shi-shan-chu": "NULL values ​​are not allowed but can be temporarily deleted",
   "fen": "divide",

--- a/src/locale/zh-CN.json
+++ b/src/locale/zh-CN.json
@@ -608,6 +608,7 @@
   "fang-xing": "方形",
   "fei-li-ji-geng-xin-mo-shi": "非立即更新模式",
   "fei-li-ji-geng-xin-mo-shi-zhi-notimmediate": "非立即更新模式 - 值：{0}",
+  "fei-shou-kong-mo-shi": "非受控模式",
   "fei-xuan-zhong-jin-yong": "非选中禁用",
   "fei-yun-xu-kong-zhi-dan-ke-lin-shi-shan-chu": "非允许空值但可临时删除",
   "fen": "分",

--- a/src/subPages/collapse/Index.vue
+++ b/src/subPages/collapse/Index.vue
@@ -48,6 +48,13 @@
       </demo-group>
 
       <demo-group :title="$t('zu-jian-bian-ti')">
+        <demo-group-item :title="$t('fei-shou-kong-mo-shi')" no-padding>
+          <wd-collapse>
+            <wd-collapse-item :title="$t('biao-qian-1')" name="item1">{{ $t('zhe-shi-yi-tiao-jian-dan-de-shi-li-wen-zi') }}</wd-collapse-item>
+            <wd-collapse-item :title="$t('biao-qian-2')" name="item2">{{ $t('zhe-shi-yi-tiao-jian-dan-de-shi-li-wen-zi-0') }}</wd-collapse-item>
+          </wd-collapse>
+        </demo-group-item>
+
         <demo-group-item :title="$t('shou-feng-qin')" no-padding>
           <wd-collapse v-model="value2" :accordion="accordion" @change="handleChange2">
             <wd-collapse-item :title="$t('biao-qian-1')" name="item1">{{ $t('zhe-shi-yi-tiao-jian-dan-de-shi-li-wen-zi') }}</wd-collapse-item>

--- a/src/uni_modules/wot-ui/components/wd-collapse-item/wd-collapse-item.vue
+++ b/src/uni_modules/wot-ui/components/wd-collapse-item/wd-collapse-item.vue
@@ -76,7 +76,7 @@ const contentStyle = computed(() => {
  * 是否选中
  */
 const isSelected = computed(() => {
-  const modelValue = collapse.value ? collapse.value.currentValue.value : []
+  const modelValue = collapse.value && collapse.value.currentValue ? collapse.value.currentValue.value : []
   const { name } = props
   return (isString(modelValue) && modelValue === name) || (isArray(modelValue) && modelValue.indexOf(name as string) >= 0)
 })

--- a/src/uni_modules/wot-ui/components/wd-collapse-item/wd-collapse-item.vue
+++ b/src/uni_modules/wot-ui/components/wd-collapse-item/wd-collapse-item.vue
@@ -76,7 +76,7 @@ const contentStyle = computed(() => {
  * 是否选中
  */
 const isSelected = computed(() => {
-  const modelValue = collapse.value ? collapse.value.props.modelValue || [] : []
+  const modelValue = collapse.value ? collapse.value.currentValue.value : []
   const { name } = props
   return (isString(modelValue) && modelValue === name) || (isArray(modelValue) && modelValue.indexOf(name as string) >= 0)
 })

--- a/src/uni_modules/wot-ui/components/wd-collapse/types.ts
+++ b/src/uni_modules/wot-ui/components/wd-collapse/types.ts
@@ -30,7 +30,8 @@ export const collapseProps = {
    * 类型: string | string[] | boolean
    */
   modelValue: {
-    type: [String, Array, Boolean] as PropType<CollapseValue>
+    type: [String, Array, Boolean] as PropType<CollapseValue>,
+    default: void 0
   },
   /**
    * 是否开启手风琴模式

--- a/src/uni_modules/wot-ui/components/wd-collapse/types.ts
+++ b/src/uni_modules/wot-ui/components/wd-collapse/types.ts
@@ -1,5 +1,7 @@
-import { type ComponentPublicInstance, type ExtractPropTypes, type InjectionKey, type PropType } from 'vue'
+import { type ComponentPublicInstance, type ComputedRef, type ExtractPropTypes, type InjectionKey, type PropType } from 'vue'
 import { baseProps, makeBooleanProp, makeNumberProp, makeStringProp } from '../../common/props'
+
+export type CollapseValue = string | string[] | boolean
 
 export type CollapseToggleAllOptions =
   | boolean
@@ -10,6 +12,7 @@ export type CollapseToggleAllOptions =
 
 export type CollapseProvide = {
   props: Partial<CollapseProps>
+  currentValue: ComputedRef<CollapseValue>
   toggle: (name: string, expanded: boolean) => void
 }
 
@@ -27,7 +30,7 @@ export const collapseProps = {
    * 类型: string | string[] | boolean
    */
   modelValue: {
-    type: [String, Array, Boolean] as PropType<string | string[] | boolean>
+    type: [String, Array, Boolean] as PropType<CollapseValue>
   },
   /**
    * 是否开启手风琴模式

--- a/src/uni_modules/wot-ui/components/wd-collapse/wd-collapse.vue
+++ b/src/uni_modules/wot-ui/components/wd-collapse/wd-collapse.vue
@@ -44,7 +44,7 @@ export default {
 
 <script lang="ts" setup>
 import wdIcon from '../wd-icon/wd-icon.vue'
-import { computed, getCurrentInstance, ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { COLLAPSE_KEY, collapseProps, type CollapseExpose, type CollapseToggleAllOptions, type CollapseValue } from './types'
 import { useChildren } from '../../composables/useChildren'
 import { isArray, isBoolean, isDef } from '../../common/util'
@@ -56,10 +56,9 @@ const emit = defineEmits<{
   (e: 'update:modelValue', value: CollapseValue): void
 }>()
 
-const instance = getCurrentInstance()!
 const { translate } = useTranslate('collapse')
 const innerValue = ref<CollapseValue>(getDefaultValue())
-const currentValue = computed<CollapseValue>(() => (hasModelValue() && isDef(props.modelValue) ? props.modelValue : innerValue.value))
+const currentValue = computed<CollapseValue>(() => (isDef(props.modelValue) ? props.modelValue : innerValue.value))
 const contentLineNum = computed<number>(() => (props.viewmore && !currentValue.value ? props.lineNum : 0))
 
 const { linkChildren, children } = useChildren(COLLAPSE_KEY)
@@ -73,16 +72,11 @@ function getDefaultValue(): CollapseValue {
   return props.accordion ? '' : []
 }
 
-function hasModelValue() {
-  const vnodeProps = instance.vnode.props || {}
-  return Object.prototype.hasOwnProperty.call(vnodeProps, 'modelValue') || Object.prototype.hasOwnProperty.call(vnodeProps, 'model-value')
-}
-
 watch(
   () => props.modelValue,
   (newVal) => {
     const { viewmore, accordion } = props
-    if (!hasModelValue() || !isDef(newVal)) {
+    if (!isDef(newVal)) {
       return
     }
     // 手风琴状态下 value 类型只能为 string
@@ -98,7 +92,7 @@ watch(
 watch(
   () => [props.accordion, props.viewmore],
   () => {
-    if (!hasModelValue() || !isDef(props.modelValue)) {
+    if (!isDef(props.modelValue)) {
       innerValue.value = getDefaultValue()
     }
   }
@@ -119,7 +113,7 @@ watch(
  * @param activeNames 选中的值
  */
 function updateChange(activeNames: CollapseValue) {
-  if (!hasModelValue() || !isDef(props.modelValue)) {
+  if (!isDef(props.modelValue)) {
     innerValue.value = activeNames
   }
   emit('update:modelValue', activeNames)

--- a/src/uni_modules/wot-ui/components/wd-collapse/wd-collapse.vue
+++ b/src/uni_modules/wot-ui/components/wd-collapse/wd-collapse.vue
@@ -7,7 +7,7 @@
     <!-- 查看更多模式 -->
     <view v-else>
       <view
-        :class="`wd-collapse__content ${!modelValue ? 'is-retract' : ''} `"
+        :class="`wd-collapse__content ${!currentValue ? 'is-retract' : ''} `"
         :style="`-webkit-line-clamp: ${contentLineNum}; -webkit-box-orient: vertical`"
       >
         <slot></slot>
@@ -19,8 +19,8 @@
         </view>
         <!-- 显示展开或折叠按钮 -->
         <block v-else>
-          <span class="wd-collapse__more-txt">{{ !modelValue ? translate('expand') : translate('retract') }}</span>
-          <view :class="`wd-collapse__arrow ${modelValue ? 'is-retract' : ''}`">
+          <span class="wd-collapse__more-txt">{{ !currentValue ? translate('expand') : translate('retract') }}</span>
+          <view :class="`wd-collapse__arrow ${currentValue ? 'is-retract' : ''}`">
             <wd-icon name="down"></wd-icon>
           </view>
         </block>
@@ -44,29 +44,47 @@ export default {
 
 <script lang="ts" setup>
 import wdIcon from '../wd-icon/wd-icon.vue'
-import { onBeforeMount, ref, watch } from 'vue'
-import { COLLAPSE_KEY, collapseProps, type CollapseExpose, type CollapseToggleAllOptions } from './types'
+import { computed, getCurrentInstance, onBeforeMount, ref, watch } from 'vue'
+import { COLLAPSE_KEY, collapseProps, type CollapseExpose, type CollapseToggleAllOptions, type CollapseValue } from './types'
 import { useChildren } from '../../composables/useChildren'
 import { isArray, isBoolean, isDef } from '../../common/util'
 import { useTranslate } from '../../composables/useTranslate'
 
 const props = defineProps(collapseProps)
 const emit = defineEmits<{
-  (e: 'change', value: { value: string | string[] | boolean }): void
-  (e: 'update:modelValue', value: string | string[] | boolean): void
+  (e: 'change', value: { value: CollapseValue }): void
+  (e: 'update:modelValue', value: CollapseValue): void
 }>()
 
+const instance = getCurrentInstance()!
 const { translate } = useTranslate('collapse')
 const contentLineNum = ref<number>(0) // 查看更多的折叠面板，收起时的显示行数
+const innerValue = ref<CollapseValue>(getDefaultValue())
+const currentValue = computed<CollapseValue>(() => (hasModelValue() && isDef(props.modelValue) ? props.modelValue : innerValue.value))
 
 const { linkChildren, children } = useChildren(COLLAPSE_KEY)
 
-linkChildren({ props, toggle })
+linkChildren({ props, currentValue, toggle })
+
+function getDefaultValue(): CollapseValue {
+  if (props.viewmore) {
+    return false
+  }
+  return props.accordion ? '' : []
+}
+
+function hasModelValue() {
+  const vnodeProps = instance.vnode.props || {}
+  return Object.prototype.hasOwnProperty.call(vnodeProps, 'modelValue') || Object.prototype.hasOwnProperty.call(vnodeProps, 'model-value')
+}
 
 watch(
   () => props.modelValue,
   (newVal) => {
     const { viewmore, accordion } = props
+    if (!hasModelValue() || !isDef(newVal)) {
+      return
+    }
     // 手风琴状态下 value 类型只能为 string
     if (accordion && typeof newVal !== 'string') {
       console.error('accordion value must be string')
@@ -75,6 +93,15 @@ watch(
     }
   },
   { deep: true }
+)
+
+watch(
+  () => [props.accordion, props.viewmore],
+  () => {
+    if (!hasModelValue() || !isDef(props.modelValue)) {
+      innerValue.value = getDefaultValue()
+    }
+  }
 )
 
 watch(
@@ -88,15 +115,18 @@ watch(
 )
 
 onBeforeMount(() => {
-  const { lineNum, viewmore, modelValue } = props
-  contentLineNum.value = viewmore && !modelValue ? lineNum : 0
+  const { lineNum, viewmore } = props
+  contentLineNum.value = viewmore && !currentValue.value ? lineNum : 0
 })
 
 /**
  * 更新绑定值
  * @param activeNames 选中的值
  */
-function updateChange(activeNames: string | string[] | boolean) {
+function updateChange(activeNames: CollapseValue) {
+  if (!hasModelValue() || !isDef(props.modelValue)) {
+    innerValue.value = activeNames
+  }
   emit('update:modelValue', activeNames)
   emit('change', {
     value: activeNames
@@ -109,13 +139,16 @@ function updateChange(activeNames: string | string[] | boolean) {
  * @param expanded 是否展开
  */
 function toggle(name: string, expanded: boolean) {
-  const { accordion, modelValue } = props
+  const { accordion } = props
+  const modelValue = currentValue.value
   if (accordion) {
     updateChange(name === modelValue ? '' : name)
   } else if (expanded) {
-    updateChange((modelValue as string[]).concat(name))
+    const activeNames = isArray(modelValue) ? modelValue : []
+    updateChange(activeNames.concat(name))
   } else {
-    updateChange((modelValue as string[]).filter((activeName) => activeName !== name))
+    const activeNames = isArray(modelValue) ? modelValue : []
+    updateChange(activeNames.filter((activeName) => activeName !== name))
   }
 }
 
@@ -149,10 +182,7 @@ const toggleAll = (options: CollapseToggleAllOptions = {}) => {
  * 查看更多点击
  */
 function handleMore() {
-  emit('update:modelValue', !props.modelValue)
-  emit('change', {
-    value: !props.modelValue
-  })
+  updateChange(!currentValue.value)
 }
 
 defineExpose<CollapseExpose>({

--- a/src/uni_modules/wot-ui/components/wd-collapse/wd-collapse.vue
+++ b/src/uni_modules/wot-ui/components/wd-collapse/wd-collapse.vue
@@ -44,7 +44,7 @@ export default {
 
 <script lang="ts" setup>
 import wdIcon from '../wd-icon/wd-icon.vue'
-import { computed, getCurrentInstance, onBeforeMount, ref, watch } from 'vue'
+import { computed, getCurrentInstance, ref, watch } from 'vue'
 import { COLLAPSE_KEY, collapseProps, type CollapseExpose, type CollapseToggleAllOptions, type CollapseValue } from './types'
 import { useChildren } from '../../composables/useChildren'
 import { isArray, isBoolean, isDef } from '../../common/util'
@@ -58,9 +58,9 @@ const emit = defineEmits<{
 
 const instance = getCurrentInstance()!
 const { translate } = useTranslate('collapse')
-const contentLineNum = ref<number>(0) // 查看更多的折叠面板，收起时的显示行数
 const innerValue = ref<CollapseValue>(getDefaultValue())
 const currentValue = computed<CollapseValue>(() => (hasModelValue() && isDef(props.modelValue) ? props.modelValue : innerValue.value))
+const contentLineNum = computed<number>(() => (props.viewmore && !currentValue.value ? props.lineNum : 0))
 
 const { linkChildren, children } = useChildren(COLLAPSE_KEY)
 
@@ -113,11 +113,6 @@ watch(
   },
   { deep: true, immediate: true }
 )
-
-onBeforeMount(() => {
-  const { lineNum, viewmore } = props
-  contentLineNum.value = viewmore && !currentValue.value ? lineNum : 0
-})
 
 /**
  * 更新绑定值

--- a/tests/components/wd-collapse.test.ts
+++ b/tests/components/wd-collapse.test.ts
@@ -71,6 +71,39 @@ describe('WdCollapse', () => {
     expect(wrapper.emitted('change')?.[0]).toEqual([{ value: true }])
   })
 
+  // 测试非受控查看更多模式
+  test('未传modelValue时查看更多模式可自行切换', async () => {
+    const wrapper = mount(WdCollapse, {
+      props: {
+        viewmore: true
+      },
+      slots: {
+        default: '<div>这是一段很长的内容，需要折叠起来，点击查看更多才能看到全部内容。</div>'
+      },
+      global: {
+        components: {
+          WdIcon
+        }
+      }
+    })
+
+    await nextTick()
+
+    expect(wrapper.find('.wd-collapse__content').classes()).toContain('is-retract')
+
+    await wrapper.find('.wd-collapse__more').trigger('click')
+    await nextTick()
+
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([true])
+    expect(wrapper.find('.wd-collapse__content').classes()).not.toContain('is-retract')
+
+    await wrapper.find('.wd-collapse__more').trigger('click')
+    await nextTick()
+
+    expect(wrapper.emitted('update:modelValue')?.[1]).toEqual([false])
+    expect(wrapper.find('.wd-collapse__content').classes()).toContain('is-retract')
+  })
+
   // 测试自定义类名
   test('应用自定义类名', async () => {
     const customClass = 'custom-collapse'
@@ -593,6 +626,37 @@ describe('WdCollapse and WdCollapseItem Integration', () => {
     expect(wrapper.html()).toContain('标签2')
   })
 
+  // 测试普通模式非受控使用
+  test('works without modelValue in normal mode', async () => {
+    const wrapper = mount(WdCollapse, {
+      slots: {
+        default: `
+          <wd-collapse-item title="标签1" name="item1">内容1</wd-collapse-item>
+          <wd-collapse-item title="标签2" name="item2">内容2</wd-collapse-item>
+        `
+      },
+      global: {
+        components: {
+          WdIcon,
+          WdCollapseItem
+        }
+      }
+    })
+
+    await nextTick()
+
+    const items = wrapper.findAllComponents(WdCollapseItem)
+    await items[0].find('.wd-collapse-item__header').trigger('click')
+
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([['item1']])
+    expect(wrapper.emitted('change')?.[0]).toEqual([{ value: ['item1'] }])
+
+    await items[1].find('.wd-collapse-item__header').trigger('click')
+
+    expect(wrapper.emitted('update:modelValue')?.[1]).toEqual([['item1', 'item2']])
+    expect(wrapper.emitted('change')?.[1]).toEqual([{ value: ['item1', 'item2'] }])
+  })
+
   // 测试手风琴模式
   test('works in accordion mode', async () => {
     const wrapper = mount(WdCollapse, {
@@ -622,6 +686,40 @@ describe('WdCollapse and WdCollapseItem Integration', () => {
 
     // 应该发出更新事件，将值更改为 'item2'
     expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['item2'])
+  })
+
+  // 测试手风琴非受控使用
+  test('works without modelValue in accordion mode', async () => {
+    const wrapper = mount(WdCollapse, {
+      props: {
+        accordion: true
+      },
+      slots: {
+        default: `
+          <wd-collapse-item title="标签1" name="item1">内容1</wd-collapse-item>
+          <wd-collapse-item title="标签2" name="item2">内容2</wd-collapse-item>
+        `
+      },
+      global: {
+        components: {
+          WdIcon,
+          WdCollapseItem
+        }
+      }
+    })
+
+    await nextTick()
+
+    const items = wrapper.findAllComponents(WdCollapseItem)
+    await items[1].find('.wd-collapse-item__header').trigger('click')
+
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['item2'])
+    expect(wrapper.emitted('change')?.[0]).toEqual([{ value: 'item2' }])
+
+    await items[0].find('.wd-collapse-item__header').trigger('click')
+
+    expect(wrapper.emitted('update:modelValue')?.[1]).toEqual(['item1'])
+    expect(wrapper.emitted('change')?.[1]).toEqual([{ value: 'item1' }])
   })
 
   // 测试禁用项

--- a/tests/components/wd-collapse.test.ts
+++ b/tests/components/wd-collapse.test.ts
@@ -104,6 +104,35 @@ describe('WdCollapse', () => {
     expect(wrapper.find('.wd-collapse__content').classes()).toContain('is-retract')
   })
 
+  // 测试查看更多模式初始展开后收起时更新行数
+  test('查看更多模式初始展开后收起时恢复收起行数', async () => {
+    const wrapper = mount(WdCollapse, {
+      props: {
+        viewmore: true,
+        modelValue: true,
+        lineNum: 3
+      },
+      slots: {
+        default: '<div>这是一段很长的内容，需要折叠起来，点击查看更多才能看到全部内容。</div>'
+      },
+      global: {
+        components: {
+          WdIcon
+        }
+      }
+    })
+
+    await nextTick()
+
+    expect(wrapper.find('.wd-collapse__content').attributes('style')).toContain('-webkit-line-clamp: 0')
+
+    await wrapper.setProps({ modelValue: false })
+    await nextTick()
+
+    expect(wrapper.find('.wd-collapse__content').classes()).toContain('is-retract')
+    expect(wrapper.find('.wd-collapse__content').attributes('style')).toContain('-webkit-line-clamp: 3')
+  })
+
   // 测试自定义类名
   test('应用自定义类名', async () => {
     const customClass = 'custom-collapse'


### PR DESCRIPTION
✅ Closes: #74

<!--
请务必阅读[贡献指南](https://github.com/wot-ui/wot-ui/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [x] 站点、文档改进
- [x] 演示代码改进
- [x] 组件样式/交互改进
- [x] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [x] 功能增强
- [x] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

关联 issue：#74

### 💡 需求背景和解决方案

该 PR 解决 `wd-collapse` 必须绑定 `v-model/modelValue` 才能正常展开/收起的问题。对于只需要本地折叠交互、不关心当前展开值的使用场景，使用方现在可以省略 `v-model`。

最终实现：

- `wd-collapse` 支持非受控模式：未传 `modelValue` 时由组件内部维护展开状态。
- 普通模式默认内部值为 `[]`。
- 手风琴模式默认内部值为 `''`。
- 查看更多模式默认内部值为 `false`。
- 传入 `v-model/modelValue` 时仍保持受控模式，兼容现有用法。
- `change` 与 `update:modelValue` 事件仍正常触发。
- 文档、英文文档、Demo、国际化文案和单元测试已同步补充。

用法示例：

```html
<wd-collapse>
  <wd-collapse-item title="标签1" name="item1">这是一条简单的示例文字。</wd-collapse-item>
  <wd-collapse-item title="标签2" name="item2">这是一条简单的示例文字。</wd-collapse-item>
</wd-collapse>
```

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 折叠组件新增“非受控模式”示例：不绑定 `v-model` 时由组件自动维护展开/收起状态。
* **文档**
  * 更新中英文文档与属性说明，补充非受控模式说明及示例（含 `wd-collapse` 的 `v-model` 行为描述）。
* **Bug Fixes**
  * 修正未绑定 `v-model` 时的状态同步与交互展示不一致问题，事件触发值与当前状态保持一致。
* **测试**
  * 新增非受控场景用例（普通/手风琴/查看更多），覆盖样式、行数恢复与 `update:modelValue/change` 触发。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->