### PR TITLE
feat: ✨ 支持 icon 相关组件透传 iconPrefix 与 cssIcon

### DIFF
--- a/docs/component/avatar.md
+++ b/docs/component/avatar.md
@@ -191,6 +191,8 @@ const handleClick = () => {
 | src | 图片地址 | string | `''` |
 | text | 文本内容 | string | `''` |
 | icon | 图标名称，使用 wd-icon 组件 | string | `''` |
+| icon-prefix | 图标类名前缀，用法参考 Icon 组件 | `string` | - |
+| css-icon | CSS 图标，用法参考 Icon 组件 | `boolean \| string` | `false` |
 | size | 头像尺寸，支持 `large / medium / normal / small` 或自定义数值/单位字符串 | string \| number | normal |
 | shape | 头像形状，支持 `round / square` | string | round |
 | bg-color | 背景颜色 | string | `''` |

--- a/docs/component/cell.md
+++ b/docs/component/cell.md
@@ -80,6 +80,12 @@
 </wd-cell-group>
 ```
 
+如果 `prefix-icon` 和 `suffix-icon` 都使用 CSS 图标，推荐将 `css-icon` 设置为 `true`，并分别把 `prefix-icon`、`suffix-icon` 写成对应的 CSS 图标类名。若直接给 `css-icon` 传字符串类名，前后图标会共用同一个 CSS 类名。
+
+```html
+<wd-cell css-icon prefix-icon="i-carbon-user" suffix-icon="i-carbon-chevron-right" />
+```
+
 ### 大尺寸
 
 ```html

--- a/docs/component/cell.md
+++ b/docs/component/cell.md
@@ -209,6 +209,7 @@
 | suffix-icon | 后置图标名 | string | - |
 | icon-size | 图标大小 | `string \| number` | - |
 | icon-prefix | 图标类名前缀 | string | - |
+| css-icon | CSS 图标，用法参考 Icon 组件 | `boolean \| string` | `false` |
 | to | 跳转地址 | string | - |
 | replace | 跳转时是否替换当前页面历史 | boolean | false |
 | clickable | 是否开启点击反馈 | boolean | false |

--- a/docs/component/empty.md
+++ b/docs/component/empty.md
@@ -78,6 +78,8 @@
 | 参数 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
 | icon | 缺省图标名称或图片 URL | string | `empty` |
+| icon-prefix | 图标类名前缀，用法参考 Icon 组件 | `string` | - |
+| css-icon | CSS 图标，用法参考 Icon 组件 | `boolean \| string` | `false` |
 | icon-size | 图标或图片大小，默认单位为 px | string / number | - |
 | tip | 提示文案 | string | - |
 

--- a/docs/component/form.md
+++ b/docs/component/form.md
@@ -1480,6 +1480,7 @@ function handleIconClick() {
 | prefix-icon | 前置图标类名 | `string` | - |
 | icon-size | 图标大小 | `string \| number` | - |
 | icon-prefix | 类名前缀，用于使用自定义图标 | `string` | - |
+| css-icon | CSS 图标，用法参考 Icon 组件 | `boolean \| string` | `false` |
 | label | 描述信息 | `string` | - |
 | clickable | 是否开启点击反馈 | `boolean` | `false` |
 | is-link | 是否展示右侧箭头并开启点击反馈 | `boolean` | `false` |

--- a/docs/component/grid.md
+++ b/docs/component/grid.md
@@ -238,6 +238,7 @@
 | icon | 图标名称，可选值见 `wd-icon` 组件 | `string` | - |
 | icon-color | 图标颜色 | `string` | - |
 | icon-prefix | 图标类名前缀 | `string` | - |
+| css-icon | CSS 图标，用法参考 Icon 组件 | `boolean \| string` | `false` |
 | is-dot | 是否显示图标右上角小红点 | `boolean` | `false` |
 | value | 图标右上角徽标显示值 | `string \| number` | - |
 | max | 图标右上角徽标最大值，超过最大值会显示 `{max}+` | `number` | `99` |

--- a/docs/component/input.md
+++ b/docs/component/input.md
@@ -111,6 +111,12 @@ function handleInput(event) {
 />
 ```
 
+如果前后图标都使用 CSS 图标，推荐将 `css-icon` 设置为 `true`，并分别把 `prefix-icon`、`suffix-icon` 写成对应的 CSS 图标类名。若直接给 `css-icon` 传字符串类名，前后图标会共用同一个 CSS 类名。
+
+```html
+<wd-input css-icon prefix-icon="i-carbon-search" suffix-icon="i-carbon-send" />
+```
+
 ### 后缀插槽
 
 通过 `suffix` 插槽自定义后缀内容。

--- a/docs/component/input.md
+++ b/docs/component/input.md
@@ -187,6 +187,8 @@ function handleInput(event) {
 | show-password | 是否显示密码切换按钮 | `boolean` | `false` |
 | prefix-icon | 前置图标名称 | `string` | - |
 | suffix-icon | 后置图标名称 | `string` | - |
+| icon-prefix | 图标类名前缀，用法参考 Icon 组件 | `string` | - |
+| css-icon | CSS 图标，用法参考 Icon 组件 | `boolean \| string` | `false` |
 | show-word-limit | 是否显示字数统计，需要同时设置 `maxlength` | `boolean` | `false` |
 | error | 是否展示错误状态 | `boolean` | `false` |
 | align-right | 输入内容是否右对齐 | `boolean` | `false` |

--- a/docs/component/rate.md
+++ b/docs/component/rate.md
@@ -64,6 +64,12 @@ function handleChange({ value }: { value: number }) {
 <wd-rate v-model="value" block icon="thumb-down-fill" active-icon="thumb-up-fill" active-color="var(--wot-green-6)" />
 ```
 
+如果未选中和选中图标都使用 CSS 图标，推荐将 `css-icon` 设置为 `true`，并分别把 `icon`、`active-icon` 写成对应的 CSS 图标类名。若直接给 `css-icon` 传字符串类名，未选中和选中图标会共用同一个 CSS 类名。
+
+```html
+<wd-rate v-model="value" css-icon icon="i-carbon-star" active-icon="i-carbon-star-filled" />
+```
+
 ### 修改大小与间隔
 
 通过 `size` 修改图标大小，`space` 修改图标间距。

--- a/docs/component/rate.md
+++ b/docs/component/rate.md
@@ -104,6 +104,8 @@ function handleChange({ value }: { value: number }) {
 | active-color | 选中图标颜色，支持 `string` 或 `string[]` | `string \| string[]` | - |
 | icon | 未选中图标类名 | `string` | `'star-fill'` |
 | active-icon | 选中图标类名 | `string` | `'star-fill'` |
+| icon-prefix | 图标类名前缀，用法参考 Icon 组件 | `string` | - |
+| css-icon | CSS 图标，用法参考 Icon 组件 | `boolean \| string` | `false` |
 | disabled | 是否禁用 | `boolean` | `false` |
 | allow-half | 是否允许半选 | `boolean` | `false` |
 | clearable | 是否允许再次点击后清除 | `boolean` | `false` |
@@ -116,4 +118,3 @@ function handleChange({ value }: { value: number }) {
 | 事件名称 | 说明 | 参数 |
 | --- | --- | --- |
 | change | 点击图标修改分值时触发 | `{ value }` |
-

--- a/docs/component/sidebar.md
+++ b/docs/component/sidebar.md
@@ -106,6 +106,8 @@ sidebar 也可以作为左侧目录，右侧内容区按当前选中项整屏切
 | badge | 徽标显示值 | `string \| number` | - |
 | badge-props | 自定义徽标属性，会透传给 Badge 组件 | `Partial<BadgeProps>` | - |
 | icon | 图标名称 | `string` | - |
+| icon-prefix | 图标类名前缀，用法参考 Icon 组件 | `string` | - |
+| css-icon | CSS 图标，用法参考 Icon 组件 | `boolean \| string` | `false` |
 | is-dot | 是否显示点状徽标 | `boolean` | `false` |
 | max | 徽标最大值 | `number` | `99` |
 | disabled | 是否禁用当前选项 | `boolean` | `false` |
@@ -117,4 +119,3 @@ sidebar 也可以作为左侧目录，右侧内容区按当前选中项整屏切
 | name | 说明 |
 | --- | --- |
 | icon | 自定义图标内容 |
-

--- a/docs/component/slide-verify.md
+++ b/docs/component/slide-verify.md
@@ -58,6 +58,12 @@ function handleFail() {
 <wd-slide-verify icon="arrow-right" success-icon="thumb-up-fill" />
 ```
 
+如果滑块图标和成功图标都使用 CSS 图标，推荐将 `css-icon` 设置为 `true`，并分别把 `icon`、`success-icon` 写成对应的 CSS 图标类名。若直接给 `css-icon` 传字符串类名，滑块图标和成功图标会共用同一个 CSS 类名。
+
+```html
+<wd-slide-verify css-icon icon="i-carbon-arrow-right" success-icon="i-carbon-checkmark" />
+```
+
 ## 特殊样式
 
 ### 自定义容错范围

--- a/docs/component/slide-verify.md
+++ b/docs/component/slide-verify.md
@@ -121,6 +121,8 @@ function handleReset() {
 | active-background-color | 激活时的背景颜色 | string | - |
 | icon | 滑块图标名称 | string | `double-right` |
 | success-icon | 成功图标名称 | string | `check-circle-fill` |
+| icon-prefix | 图标类名前缀，用法参考 Icon 组件 | `string` | - |
+| css-icon | CSS 图标，用法参考 Icon 组件 | `boolean \| string` | `false` |
 | icon-size | 图标大小 | string / number | - |
 | success-icon-size | 成功图标大小 | string / number | - |
 

--- a/docs/component/tabbar.md
+++ b/docs/component/tabbar.md
@@ -248,6 +248,8 @@ const tabbar = ref(1)
 | title | 标签页标题 | `string` | - |
 | name | 唯一标识符，不传时默认使用索引值 | `string \| number` | - |
 | icon | 图标名称 | `string` | - |
+| icon-prefix | 图标类名前缀，用法参考 Icon 组件 | `string` | - |
+| css-icon | CSS 图标，用法参考 Icon 组件 | `boolean \| string` | `false` |
 | value | 徽标显示值 | `number \| string` | - |
 | is-dot | 是否显示点状徽标 | `boolean` | `false` |
 | max | 徽标最大值 | `number` | `99` |

--- a/docs/component/tag.md
+++ b/docs/component/tag.md
@@ -184,6 +184,8 @@ function handleConfirm({ value }: { value: string }) {
 | size | 标签尺寸，可选值为 `small`、`medium`、`large`、`extra-large`、`default` | `TagSize` | `default` |
 | type | 标签类型，可选值为 `default`、`primary`、`success`、`warning`、`danger`、`volcano`、`lightblue`、`cyan`、`pink`、`purple` | `TagType` | `default` |
 | icon | 左侧图标 | `string` | `''` |
+| icon-prefix | 图标类名前缀，用法参考 Icon 组件 | `string` | - |
+| css-icon | CSS 图标，用法参考 Icon 组件 | `boolean \| string` | `false` |
 | closable | 是否可关闭 | `boolean` | `false` |
 | dynamic | 是否为新增标签 | `boolean` | `false` |
 | color | 文字颜色 | `string` | `''` |

--- a/docs/component/textarea.md
+++ b/docs/component/textarea.md
@@ -118,6 +118,9 @@ const value = ref('')
 | readonly | 是否只读 | `boolean` | `false` |
 | maxlength | 最大输入长度，设置为 `-1` 时不限制长度 | `number` | `-1` |
 | clearable | 是否显示清空按钮 | `boolean` | `false` |
+| prefix-icon | 前置图标名称 | `string` | - |
+| icon-prefix | 图标类名前缀，用法参考 Icon 组件 | `string` | - |
+| css-icon | CSS 图标，用法参考 Icon 组件 | `boolean \| string` | `false` |
 | show-word-limit | 是否显示字数统计，需要同时设置 `maxlength` | `boolean` | `false` |
 | clear-trigger | 清空按钮显示时机，可选值为 `focus`、`always` | `InputClearTrigger` | `always` |
 | focus-when-clear | 点击清空按钮后是否自动聚焦 | `boolean` | `true` |

--- a/docs/en-US/component/avatar.md
+++ b/docs/en-US/component/avatar.md
@@ -191,6 +191,8 @@ Use `vertical` property to enable vertical direction stack display.
 | src | Image URL | string | `''` |
 | text | Text content | string | `''` |
 | icon | Icon name, uses wd-icon component | string | `''` |
+| icon-prefix | Icon class prefix, see Icon component for usage | `string` | - |
+| css-icon | CSS icon, see Icon component for usage | `boolean \| string` | `false` |
 | size | Avatar size, supports `large / medium / normal / small` or custom number/unit string | string \| number | normal |
 | shape | Avatar shape, supports `round / square` | string | round |
 | bg-color | Background color | string | `''` |

--- a/docs/en-US/component/cell.md
+++ b/docs/en-US/component/cell.md
@@ -209,6 +209,7 @@ Set `prefix-icon` to use built-in icons, or use `prefix` slot to customize leadi
 | suffix-icon | Trailing icon name | string | - |
 | icon-size | Icon size | `string \| number` | - |
 | icon-prefix | Icon class prefix | string | - |
+| css-icon | CSS icon, see Icon component for usage | `boolean \| string` | `false` |
 | to | Navigation address | string | - |
 | replace | Whether to replace current page history when navigating | boolean | false |
 | clickable | Whether to enable click feedback | boolean | false |

--- a/docs/en-US/component/cell.md
+++ b/docs/en-US/component/cell.md
@@ -80,6 +80,12 @@ Set `prefix-icon` to use built-in icons, or use `prefix` slot to customize leadi
 </wd-cell-group>
 ```
 
+When both `prefix-icon` and `suffix-icon` use CSS icons, it is recommended to set `css-icon` to `true` and pass each icon prop as its own CSS icon class. If you pass a string class name directly to `css-icon`, the prefix and suffix icons will share the same CSS class.
+
+```html
+<wd-cell css-icon prefix-icon="i-carbon-user" suffix-icon="i-carbon-chevron-right" />
+```
+
 ### Large Size
 
 ```html

--- a/docs/en-US/component/empty.md
+++ b/docs/en-US/component/empty.md
@@ -78,6 +78,8 @@ Recommended styles (can be added in page or global styles):
 | Parameter | Description | Type | Default Value |
 | --- | --- | --- | --- |
 | icon | Empty state icon name or image URL | string | `empty` |
+| icon-prefix | Icon class prefix, see Icon component for usage | `string` | - |
+| css-icon | CSS icon, see Icon component for usage | `boolean \| string` | `false` |
 | icon-size | Icon or image size, default unit is px | string / number | - |
 | tip | Prompt text | string | - |
 

--- a/docs/en-US/component/form.md
+++ b/docs/en-US/component/form.md
@@ -950,6 +950,7 @@ All properties of this component, in addition to supporting specific form item c
 | prefix-icon | Prefix icon class name | `string` | - |
 | icon-size | Icon size | `string \| number` | - |
 | icon-prefix | Class name prefix, used for custom icons | `string` | - |
+| css-icon | CSS icon, see Icon component for usage | `boolean \| string` | `false` |
 | label | Description information | `string` | - |
 | clickable | Whether to enable click feedback | `boolean` | `false` |
 | is-link | Whether to show right arrow and enable click feedback | `boolean` | `false` |

--- a/docs/en-US/component/grid.md
+++ b/docs/en-US/component/grid.md
@@ -238,6 +238,7 @@ Enable clickable state through `clickable` property, and set page jump through `
 | icon | Icon name, optional values see `wd-icon` component | `string` | - |
 | icon-color | Icon color | `string` | - |
 | icon-prefix | Icon class name prefix | `string` | - |
+| css-icon | CSS icon, see Icon component for usage | `boolean \| string` | `false` |
 | is-dot | Whether to show small red dot in upper right corner of icon | `boolean` | `false` |
 | value | Badge display value in upper right corner of icon | `string \| number` | - |
 | max | Badge maximum value in upper right corner of icon, exceeding maximum will display `{max}+` | `number` | `99` |

--- a/docs/en-US/component/input.md
+++ b/docs/en-US/component/input.md
@@ -111,6 +111,12 @@ Set the front and back icons through `prefix-icon` and `suffix-icon`. For icon n
 />
 ```
 
+When both prefix and suffix icons use CSS icons, it is recommended to set `css-icon` to `true` and pass each icon prop as its own CSS icon class. If you pass a string class name directly to `css-icon`, the prefix and suffix icons will share the same CSS class.
+
+```html
+<wd-input css-icon prefix-icon="i-carbon-search" suffix-icon="i-carbon-send" />
+```
+
 ### Suffix Slot
 
 Customize the suffix content through the `suffix` slot.

--- a/docs/en-US/component/input.md
+++ b/docs/en-US/component/input.md
@@ -187,6 +187,8 @@ For the current form scenario, it is recommended to use `wd-form` and `wd-form-i
 | show-password | Whether to display the password toggle button | `boolean` | `false` |
 | prefix-icon | Prefix icon name | `string` | - |
 | suffix-icon | Suffix icon name | `string` | - |
+| icon-prefix | Icon class prefix, see Icon component for usage | `string` | - |
+| css-icon | CSS icon, see Icon component for usage | `boolean \| string` | `false` |
 | show-word-limit | Whether to display character count, need to set `maxlength` at the same time | `boolean` | `false` |
 | error | Whether to display error state | `boolean` | `false` |
 | align-right | Whether the input content is right-aligned | `boolean` | `false` |

--- a/docs/en-US/component/rate.md
+++ b/docs/en-US/component/rate.md
@@ -64,6 +64,12 @@ You can set unselected and selected icons through `icon` and `active-icon` respe
 <wd-rate v-model="value" block icon="thumb-down-fill" active-icon="thumb-up-fill" active-color="var(--wot-green-6)" />
 ```
 
+When both inactive and active icons use CSS icons, it is recommended to set `css-icon` to `true` and pass `icon` and `active-icon` as their own CSS icon classes. If you pass a string class name directly to `css-icon`, inactive and active icons will share the same CSS class.
+
+```html
+<wd-rate v-model="value" css-icon icon="i-carbon-star" active-icon="i-carbon-star-filled" />
+```
+
 ### Modify Size and Spacing
 
 Modify icon size through `size`, and icon spacing through `space`.

--- a/docs/en-US/component/rate.md
+++ b/docs/en-US/component/rate.md
@@ -104,6 +104,8 @@ After setting the `clearable` property, clicking the current minimum score again
 | active-color | Selected icon color, supports `string` or `string[]` | `string \| string[]` | - |
 | icon | Unselected icon class name | `string` | `'star-fill'` |
 | active-icon | Selected icon class name | `string` | `'star-fill'` |
+| icon-prefix | Icon class prefix, see Icon component for usage | `string` | - |
+| css-icon | CSS icon, see Icon component for usage | `boolean \| string` | `false` |
 | disabled | Whether disabled | `boolean` | `false` |
 | allow-half | Whether to allow half selection | `boolean` | `false` |
 | clearable | Whether to allow clearing after clicking again | `boolean` | `false` |

--- a/docs/en-US/component/sidebar.md
+++ b/docs/en-US/component/sidebar.md
@@ -106,6 +106,8 @@ Set the `icon` property of `wd-sidebar-item` to display different icons in the n
 | badge | Badge display value | `string \| number` | - |
 | badge-props | Custom badge properties, will be passed to Badge component | `Partial<BadgeProps>` | - |
 | icon | Icon name | `string` | - |
+| icon-prefix | Icon class prefix, see Icon component for usage | `string` | - |
+| css-icon | CSS icon, see Icon component for usage | `boolean \| string` | `false` |
 | is-dot | Whether to display dot badge | `boolean` | `false` |
 | max | Badge maximum value | `number` | `99` |
 | disabled | Whether to disable the current option | `boolean` | `false` |

--- a/docs/en-US/component/slide-verify.md
+++ b/docs/en-US/component/slide-verify.md
@@ -121,6 +121,8 @@ Supports customizing content through slots.
 | active-background-color | Background color when active | string | - |
 | icon | Slider icon name | string | `double-right` |
 | success-icon | Success icon name | string | `check-circle-fill` |
+| icon-prefix | Icon class prefix, see Icon component for usage | string | - |
+| css-icon | CSS icon, see Icon component for usage | `boolean \| string` | `false` |
 | icon-size | Icon size | string / number | - |
 | success-icon-size | Success icon size | string / number | - |
 

--- a/docs/en-US/component/slide-verify.md
+++ b/docs/en-US/component/slide-verify.md
@@ -58,6 +58,12 @@ Customize icons through `icon` and `success-icon` properties.
 <wd-slide-verify icon="arrow-right" success-icon="thumb-up-fill" />
 ```
 
+When both the slider icon and success icon use CSS icons, it is recommended to set `css-icon` to `true` and pass `icon` and `success-icon` as their own CSS icon classes. If you pass a string class name directly to `css-icon`, the slider icon and success icon will share the same CSS class.
+
+```html
+<wd-slide-verify css-icon icon="i-carbon-arrow-right" success-icon="i-carbon-checkmark" />
+```
+
 ## Special Styles
 
 ### Custom Tolerance Range

--- a/docs/en-US/component/tabbar.md
+++ b/docs/en-US/component/tabbar.md
@@ -248,6 +248,8 @@ const tabbar = ref(1)
 | title | Tab title | `string` | - |
 | name | Unique identifier, defaults to index value if not passed | `string \| number` | - |
 | icon | Icon name | `string` | - |
+| icon-prefix | Icon class prefix, see Icon component for usage | `string` | - |
+| css-icon | CSS icon, see Icon component for usage | `boolean \| string` | `false` |
 | value | Badge display value | `number \| string` | - |
 | is-dot | Whether to show dot badge | `boolean` | `false` |
 | max | Badge maximum value | `number` | `99` |

--- a/docs/en-US/component/tag.md
+++ b/docs/en-US/component/tag.md
@@ -184,6 +184,8 @@ function handleConfirm({ value }: { value: string }) {
 | size | Tag size, optional values are `small`, `medium`, `large`, `extra-large`, `default` | `TagSize` | `default` |
 | type | Tag type, optional values are `default`, `primary`, `success`, `warning`, `danger`, `volcano`, `lightblue`, `cyan`, `pink`, `purple` | `TagType` | `default` |
 | icon | Left icon | `string` | `''` |
+| icon-prefix | Icon class prefix, see Icon component for usage | `string` | - |
+| css-icon | CSS icon, see Icon component for usage | `boolean \| string` | `false` |
 | closable | Whether closable | `boolean` | `false` |
 | dynamic | Whether it is an add tag | `boolean` | `false` |
 | color | Text color | `string` | `''` |

--- a/docs/en-US/component/textarea.md
+++ b/docs/en-US/component/textarea.md
@@ -118,6 +118,9 @@ For current form scenarios, it is recommended to have `wd-form` and `wd-form-ite
 | readonly | Whether read-only | `boolean` | `false` |
 | maxlength | Maximum input length, set to `-1` for unlimited length | `number` | `-1` |
 | clearable | Whether to show clear button | `boolean` | `false` |
+| prefix-icon | Prefix icon name | `string` | - |
+| icon-prefix | Icon class prefix, see Icon component for usage | `string` | - |
+| css-icon | CSS icon, see Icon component for usage | `boolean \| string` | `false` |
 | show-word-limit | Whether to show word count, requires `maxlength` to be set | `boolean` | `false` |
 | clear-trigger | Clear button display timing, optional values are `focus`, `always` | `InputClearTrigger` | `always` |
 | focus-when-clear | Whether to auto-focus after clicking clear button | `boolean` | `true` |

--- a/src/uni_modules/wot-ui/components/wd-avatar/types.ts
+++ b/src/uni_modules/wot-ui/components/wd-avatar/types.ts
@@ -68,6 +68,20 @@ export const avatarProps = {
    * 默认值: ''
    */
   icon: makeStringProp(''),
+  /**
+   * 图标类名前缀，用法参考 Icon 组件
+   * 类型: string
+   */
+  iconPrefix: String,
+  /**
+   * CSS 图标，用法参考 Icon 组件
+   * 类型: boolean | string
+   * 默认值: false
+   */
+  cssIcon: {
+    type: [Boolean, String],
+    default: false
+  },
 
   /**
    * 图片加载失败时的占位文本

--- a/src/uni_modules/wot-ui/components/wd-avatar/wd-avatar.vue
+++ b/src/uni_modules/wot-ui/components/wd-avatar/wd-avatar.vue
@@ -7,7 +7,7 @@
     <!-- 文本 -->
     <text v-else-if="text" class="wd-avatar__text">{{ text }}</text>
     <!-- 图标 -->
-    <wd-icon v-else-if="icon" :name="icon" custom-class="wd-avatar__icon" />
+    <wd-icon v-else-if="hasIcon" :name="icon" :class-prefix="iconPrefix" :css-icon="cssIcon" custom-class="wd-avatar__icon" />
   </view>
 </template>
 
@@ -42,6 +42,8 @@ const props = defineProps(avatarProps)
  */
 const emit = defineEmits(['error', 'click'])
 const slots = useSlots()
+
+const hasIcon = computed(() => Boolean(props.icon || (isString(props.cssIcon) && props.cssIcon)))
 
 // 父组件上下文：_internal 用于 avatar-group 内部的溢出计数头像，跳过父组件上下文
 const { parent: avatarGroup, index } = props._internal ? { parent: ref(null), index: ref(-1) } : useParent(AVATAR_GROUP_KEY)

--- a/src/uni_modules/wot-ui/components/wd-cell/types.ts
+++ b/src/uni_modules/wot-ui/components/wd-cell/types.ts
@@ -70,6 +70,15 @@ export const cellProps = {
    */
   iconPrefix: String,
   /**
+   * CSS 图标，用法参考 Icon 组件
+   * 类型: boolean | string
+   * 默认值: false
+   */
+  cssIcon: {
+    type: [Boolean, String],
+    default: false
+  },
+  /**
    * 标题下方的描述信息
    * 类型: string
    */

--- a/src/uni_modules/wot-ui/components/wd-cell/wd-cell.vue
+++ b/src/uni_modules/wot-ui/components/wd-cell/wd-cell.vue
@@ -20,6 +20,7 @@
             :name="prefixIcon"
             :size="iconSize"
             :class-prefix="iconPrefix"
+            :css-icon="cssIcon"
             :custom-class="`wd-cell__prefix ${customPrefixClass}`"
           ></wd-icon>
         </slot>
@@ -60,6 +61,7 @@
               :name="suffixIcon"
               :size="iconSize"
               :class-prefix="iconPrefix"
+              :css-icon="cssIcon"
               :custom-class="`wd-cell__suffix ${customSuffixClass}`"
             ></wd-icon>
           </slot>

--- a/src/uni_modules/wot-ui/components/wd-empty/types.ts
+++ b/src/uni_modules/wot-ui/components/wd-empty/types.ts
@@ -21,6 +21,20 @@ export const emptyProps = {
    */
   icon: makeStringProp('empty'),
   /**
+   * 图标类名前缀，用法参考 Icon 组件。
+   * 类型: string
+   */
+  iconPrefix: String,
+  /**
+   * CSS 图标，用法参考 Icon 组件。
+   * 类型: boolean | string
+   * 默认值: false
+   */
+  cssIcon: {
+    type: [Boolean, String],
+    default: false
+  },
+  /**
    * 图片大小，默认单位为 `px`。
    * 类型: string 或 number
    * 默认值: 空字符串

--- a/src/uni_modules/wot-ui/components/wd-empty/wd-empty.vue
+++ b/src/uni_modules/wot-ui/components/wd-empty/wd-empty.vue
@@ -1,7 +1,7 @@
 <template>
   <view :class="`wd-empty  ${customClass}`" :style="customStyle">
     <slot name="image">
-      <wd-icon :name="icon" custom-class="wd-empty__icon" :custom-style="iconStyle"></wd-icon>
+      <wd-icon :name="icon" :class-prefix="iconPrefix" :css-icon="cssIcon" custom-class="wd-empty__icon" :custom-style="iconStyle"></wd-icon>
     </slot>
     <view v-if="tip" class="wd-empty__text">{{ tip }}</view>
     <slot name="bottom" />

--- a/src/uni_modules/wot-ui/components/wd-form-item/types.ts
+++ b/src/uni_modules/wot-ui/components/wd-form-item/types.ts
@@ -50,6 +50,13 @@ export const formItemProps = {
    */
   iconPrefix: String,
   /**
+   * CSS 图标，用法参考 Icon 组件
+   */
+  cssIcon: {
+    type: [Boolean, String],
+    default: false
+  },
+  /**
    * 描述信息
    */
   label: String,

--- a/src/uni_modules/wot-ui/components/wd-form-item/wd-form-item.vue
+++ b/src/uni_modules/wot-ui/components/wd-form-item/wd-form-item.vue
@@ -9,6 +9,7 @@
     :prefix-icon="prefixIcon"
     :icon-size="iconSize"
     :icon-prefix="iconPrefix"
+    :css-icon="cssIcon"
     :required="isRequired"
     :size="formItemSize"
     :value-align="formItemValueAlign"

--- a/src/uni_modules/wot-ui/components/wd-grid-item/types.ts
+++ b/src/uni_modules/wot-ui/components/wd-grid-item/types.ts
@@ -61,6 +61,15 @@ export const gridItemProps = {
    */
   iconPrefix: String,
   /**
+   * CSS 图标，用法参考 Icon 组件
+   * 类型: boolean | string
+   * 默认值: false
+   */
+  cssIcon: {
+    type: [Boolean, String],
+    default: false
+  },
+  /**
    * 徽标显示值
    * 类型: string | number
    * 默认值: ''

--- a/src/uni_modules/wot-ui/components/wd-grid-item/wd-grid-item.vue
+++ b/src/uni_modules/wot-ui/components/wd-grid-item/wd-grid-item.vue
@@ -2,7 +2,7 @@
   <view :class="rootClass" @click="click" :style="rootStyle">
     <view :class="contentClass" :style="contentStyle" :hover-class="hoverClass">
       <slot>
-        <view class="wd-grid-item__wrapper" v-if="icon || $slots.icon">
+        <view class="wd-grid-item__wrapper" v-if="hasIcon || $slots.icon">
           <wd-badge v-bind="customBadgeProps" custom-class="wd-grid-item__badge">
             <slot name="icon">
               <wd-icon
@@ -10,6 +10,7 @@
                 :size="iconSize"
                 :color="iconColor"
                 :class-prefix="iconPrefix"
+                :css-icon="cssIcon"
                 :custom-class="`wd-grid-item__icon ${customIcon}`"
               />
             </slot>
@@ -41,7 +42,7 @@ import wdBadge from '../wd-badge/wd-badge.vue'
 import { computed, type CSSProperties } from 'vue'
 import { useParent } from '../../composables/useParent'
 import { GRID_KEY } from '../wd-grid/types'
-import { addUnit, deepAssign, isDef, isUndefined, omitBy } from '../../common/util'
+import { addUnit, deepAssign, isDef, isString, isUndefined, omitBy } from '../../common/util'
 import { gridItemProps } from './types'
 import type { BadgeProps } from '../wd-badge/types'
 
@@ -68,6 +69,8 @@ const childCount = computed(() => grid.value?.children?.length || 0)
 
 /** 图标大小（从父级 Grid 组件继承） */
 const iconSize = computed(() => grid.value?.props.iconSize)
+/** 是否渲染图标，cssIcon 字符串可作为图标类名独立渲染 */
+const hasIcon = computed(() => Boolean(props.icon || (isString(props.cssIcon) && props.cssIcon)))
 
 /**
  * 边框 CSS 类名计算

--- a/src/uni_modules/wot-ui/components/wd-input/types.ts
+++ b/src/uni_modules/wot-ui/components/wd-input/types.ts
@@ -115,6 +115,17 @@ export const inputProps = {
    */
   suffixIcon: String,
   /**
+   * 图标类名前缀，用法参考 Icon 组件
+   */
+  iconPrefix: String,
+  /**
+   * CSS 图标，用法参考 Icon 组件
+   */
+  cssIcon: {
+    type: [Boolean, String],
+    default: false
+  },
+  /**
    * 显示字数限制，需要同时设置 maxlength
    */
   showWordLimit: makeBooleanProp(false),

--- a/src/uni_modules/wot-ui/components/wd-input/wd-input.vue
+++ b/src/uni_modules/wot-ui/components/wd-input/wd-input.vue
@@ -1,7 +1,14 @@
 <template>
   <view :class="rootClass" :style="customStyle" @click="handleClick">
     <view v-if="prefixIcon || $slots.prefix" class="wd-input__prefix">
-      <wd-icon v-if="prefixIcon && !$slots.prefix" custom-class="wd-input__icon" :name="prefixIcon" @click="onClickPrefixIcon" />
+      <wd-icon
+        v-if="prefixIcon && !$slots.prefix"
+        custom-class="wd-input__icon"
+        :name="prefixIcon"
+        :class-prefix="iconPrefix"
+        :css-icon="cssIcon"
+        @click="onClickPrefixIcon"
+      />
       <slot v-else name="prefix"></slot>
     </view>
     <input
@@ -44,7 +51,14 @@
       <wd-icon v-if="showClear" custom-class="wd-input__clear" name="close-circle" @click="handleClear" />
       <wd-icon v-if="showPassword" custom-class="wd-input__icon" :name="isPwdVisible ? 'eye' : 'eye-invisible'" @click="togglePwdVisible" />
       <view v-if="showWordCount" class="wd-input__count">{{ currentLength }}/{{ maxlength }}</view>
-      <wd-icon v-if="suffixIcon && !$slots.suffix" custom-class="wd-input__icon" :name="suffixIcon" @click="onClickSuffixIcon" />
+      <wd-icon
+        v-if="suffixIcon && !$slots.suffix"
+        custom-class="wd-input__icon"
+        :name="suffixIcon"
+        :class-prefix="iconPrefix"
+        :css-icon="cssIcon"
+        @click="onClickSuffixIcon"
+      />
       <slot v-else name="suffix"></slot>
     </view>
   </view>

--- a/src/uni_modules/wot-ui/components/wd-rate/types.ts
+++ b/src/uni_modules/wot-ui/components/wd-rate/types.ts
@@ -60,6 +60,20 @@ export const rateProps = {
    */
   activeIcon: makeStringProp('star-fill'),
   /**
+   * 图标类名前缀，用法参考 Icon 组件
+   * 类型: string
+   */
+  iconPrefix: String,
+  /**
+   * CSS 图标，用法参考 Icon 组件
+   * 类型: boolean | string
+   * 默认值: false
+   */
+  cssIcon: {
+    type: [Boolean, String],
+    default: false
+  },
+  /**
    * 是否禁用
    * 类型: boolean
    * 默认值: false

--- a/src/uni_modules/wot-ui/components/wd-rate/wd-rate.vue
+++ b/src/uni_modules/wot-ui/components/wd-rate/wd-rate.vue
@@ -10,6 +10,8 @@
       <wd-icon
         :custom-class="`wd-rate__item-star ${rate === '100%' ? 'wd-rate__item-star--active' : ''}`"
         :name="isActive(rate) ? activeIcon : icon"
+        :class-prefix="iconPrefix"
+        :css-icon="cssIcon"
         :custom-style="`${rate === '100%' ? iconActiveStyle : iconStyle} ${iconSize}`"
         @click="handleClick(index, false)"
       />
@@ -17,6 +19,8 @@
         <wd-icon
           :custom-class="`wd-rate__item-star ${rate !== '0' ? 'wd-rate__item-star--active' : ''}`"
           :name="isActive(rate) ? activeIcon : icon"
+          :class-prefix="iconPrefix"
+          :css-icon="cssIcon"
           :custom-style="`${rate !== '0' ? iconActiveStyle : iconStyle} ${iconSize}`"
         />
       </view>

--- a/src/uni_modules/wot-ui/components/wd-sidebar-item/types.ts
+++ b/src/uni_modules/wot-ui/components/wd-sidebar-item/types.ts
@@ -14,6 +14,13 @@ export const sidebarItemProps = {
   badgeProps: Object as PropType<Partial<BadgeProps>>,
   /** 图标 */
   icon: String,
+  /** 图标类名前缀，用法参考 Icon 组件 */
+  iconPrefix: String,
+  /** CSS 图标，用法参考 Icon 组件 */
+  cssIcon: {
+    type: [Boolean, String],
+    default: false
+  },
   /** 是否点状徽标 */
   isDot: {
     type: Boolean,

--- a/src/uni_modules/wot-ui/components/wd-sidebar-item/wd-sidebar-item.vue
+++ b/src/uni_modules/wot-ui/components/wd-sidebar-item/wd-sidebar-item.vue
@@ -7,8 +7,8 @@
     :style="customStyle"
   >
     <slot name="icon"></slot>
-    <template v-if="!$slots.icon && icon">
-      <wd-icon custom-class="wd-sidebar-item__icon" :name="icon"></wd-icon>
+    <template v-if="!$slots.icon && hasIcon">
+      <wd-icon custom-class="wd-sidebar-item__icon" :name="icon" :class-prefix="iconPrefix" :css-icon="cssIcon"></wd-icon>
     </template>
     <wd-badge v-bind="customBadgeProps" custom-class="wd-sidebar-item__badge">
       {{ label }}
@@ -37,11 +37,13 @@ import { useParent } from '../../composables/useParent'
 import { SIDEBAR_KEY } from '../wd-sidebar/types'
 import { sidebarItemProps } from './types'
 import type { BadgeProps } from '../wd-badge/types'
-import { deepAssign, isDef, isUndefined, omitBy } from '../../common/util'
+import { deepAssign, isDef, isString, isUndefined, omitBy } from '../../common/util'
 
 const props = defineProps(sidebarItemProps)
 
 const { parent: sidebar } = useParent(SIDEBAR_KEY)
+
+const hasIcon = computed(() => Boolean(props.icon || (isString(props.cssIcon) && props.cssIcon)))
 
 const customBadgeProps = computed(() => {
   const badgeProps: Partial<BadgeProps> = deepAssign(

--- a/src/uni_modules/wot-ui/components/wd-slide-verify/types.ts
+++ b/src/uni_modules/wot-ui/components/wd-slide-verify/types.ts
@@ -59,6 +59,20 @@ export const slideVerifyProps = {
    * 默认值: 'check-circle-fill'
    */
   successIcon: makeStringProp('check-circle-fill'),
+  /**
+   * 图标类名前缀，用法参考 Icon 组件
+   * 类型: string
+   */
+  iconPrefix: String,
+  /**
+   * CSS 图标，用法参考 Icon 组件
+   * 类型: boolean | string
+   * 默认值: false
+   */
+  cssIcon: {
+    type: [Boolean, String],
+    default: false
+  },
 
   /**
    * 图标大小（单位：px）

--- a/src/uni_modules/wot-ui/components/wd-slide-verify/wd-slide-verify.vue
+++ b/src/uni_modules/wot-ui/components/wd-slide-verify/wd-slide-verify.vue
@@ -18,11 +18,17 @@
       <!-- 滑块 -->
       <view class="wd-slide-verify__button" @touchstart.prevent="onTouchStart" @touchmove.prevent="onTouchMove" @touchend="onTouchEnd">
         <slot v-if="isPass" name="success-icon">
-          <wd-icon custom-class="wd-slide-verify__button-icon wd-slide-verify__button-icon--success" :name="successIcon" :size="successIconSize" />
+          <wd-icon
+            custom-class="wd-slide-verify__button-icon wd-slide-verify__button-icon--success"
+            :name="successIcon"
+            :size="successIconSize"
+            :class-prefix="iconPrefix"
+            :css-icon="cssIcon"
+          />
         </slot>
 
         <slot v-else name="icon">
-          <wd-icon custom-class="wd-slide-verify__button-icon" :name="icon" :size="iconSize" />
+          <wd-icon custom-class="wd-slide-verify__button-icon" :name="icon" :size="iconSize" :class-prefix="iconPrefix" :css-icon="cssIcon" />
         </slot>
       </view>
     </view>

--- a/src/uni_modules/wot-ui/components/wd-tabbar-item/types.ts
+++ b/src/uni_modules/wot-ui/components/wd-tabbar-item/types.ts
@@ -25,6 +25,17 @@ export const tabbarItemProps = {
    */
   icon: String,
   /**
+   * 图标类名前缀，用法参考 Icon 组件
+   */
+  iconPrefix: String,
+  /**
+   * CSS 图标，用法参考 Icon 组件
+   */
+  cssIcon: {
+    type: [Boolean, String],
+    default: false
+  },
+  /**
    * 徽标显示值
    */
   value: [Number, String] as PropType<number | string>,

--- a/src/uni_modules/wot-ui/components/wd-tabbar-item/wd-tabbar-item.vue
+++ b/src/uni_modules/wot-ui/components/wd-tabbar-item/wd-tabbar-item.vue
@@ -4,9 +4,11 @@
       <wd-badge v-bind="customBadgeProps">
         <view class="wd-tabbar-item__body">
           <slot name="icon" :active="active"></slot>
-          <template v-if="!$slots.icon && icon">
+          <template v-if="!$slots.icon && hasIcon">
             <wd-icon
               :name="icon"
+              :class-prefix="iconPrefix"
+              :css-icon="cssIcon"
               :custom-style="textStyle"
               :custom-class="`wd-tabbar-item__body-icon ${active ? 'is-active' : 'is-inactive'}`"
             ></wd-icon>
@@ -33,7 +35,7 @@ export default {
 import wdBadge from '../wd-badge/wd-badge.vue'
 import wdIcon from '../wd-icon/wd-icon.vue'
 import { type CSSProperties, computed } from 'vue'
-import { deepAssign, isDef, isUndefined, objToStyle, omitBy } from '../../common/util'
+import { deepAssign, isDef, isString, isUndefined, objToStyle, omitBy } from '../../common/util'
 import { useParent } from '../../composables/useParent'
 import { TABBAR_KEY } from '../wd-tabbar/types'
 import { tabbarItemProps } from './types'
@@ -42,6 +44,8 @@ import type { BadgeProps } from '../wd-badge/types'
 const props = defineProps(tabbarItemProps)
 
 const { parent: tabbar, index } = useParent(TABBAR_KEY)
+
+const hasIcon = computed(() => Boolean(props.icon || (isString(props.cssIcon) && props.cssIcon)))
 
 const customBadgeProps = computed(() => {
   const badgeProps: Partial<BadgeProps> = deepAssign(

--- a/src/uni_modules/wot-ui/components/wd-tag/types.ts
+++ b/src/uni_modules/wot-ui/components/wd-tag/types.ts
@@ -43,6 +43,20 @@ export const tagProps = {
    */
   icon: makeStringProp(''),
   /**
+   * 图标类名前缀，用法参考 Icon 组件
+   * 类型: string
+   */
+  iconPrefix: String,
+  /**
+   * CSS 图标，用法参考 Icon 组件
+   * 类型: boolean | string
+   * 默认值: false
+   */
+  cssIcon: {
+    type: [Boolean, String],
+    default: false
+  },
+  /**
    * 是否可关闭（只对圆角类型支持）
    * 类型: boolean
    * 默认值: false

--- a/src/uni_modules/wot-ui/components/wd-tag/wd-tag.vue
+++ b/src/uni_modules/wot-ui/components/wd-tag/wd-tag.vue
@@ -19,8 +19,8 @@
     </view>
 
     <template v-else>
-      <slot name="icon" v-if="$slots.icon || icon">
-        <wd-icon :name="icon" custom-class="wd-tag__icon" />
+      <slot name="icon" v-if="$slots.icon || hasIcon">
+        <wd-icon :name="icon" :class-prefix="iconPrefix" :css-icon="cssIcon" custom-class="wd-tag__icon" />
       </slot>
       <view class="wd-tag__text" :style="textStyle" v-if="$slots.default">
         <slot />
@@ -46,7 +46,7 @@ export default {
 </script>
 <script lang="ts" setup>
 import wdIcon from '../wd-icon/wd-icon.vue'
-import { objToStyle, isUndefined } from '../../common/util'
+import { objToStyle, isString, isUndefined } from '../../common/util'
 import { computed, ref } from 'vue'
 import { useTranslate } from '../../composables/useTranslate'
 import { tagProps } from './types'
@@ -57,6 +57,8 @@ const emit = defineEmits(['click', 'close', 'confirm'])
 
 const { translate } = useTranslate('tag')
 const globalConfig = useGlobalConfig()
+
+const hasIcon = computed(() => Boolean(props.icon || (isString(props.cssIcon) && props.cssIcon)))
 
 const effectiveSize = computed(() => {
   return props.size || globalConfig.value.tag?.size || 'default'

--- a/src/uni_modules/wot-ui/components/wd-textarea/index.scss
+++ b/src/uni_modules/wot-ui/components/wd-textarea/index.scss
@@ -70,6 +70,14 @@ $textarea-error-color: var(--wot-textarea-error-color, $danger-main) !default;
     }
   }
 
+  @include edeep(prefix) {
+    flex: none;
+    margin-right: $textarea-icon-margin;
+    font-size: $textarea-icon-font-size;
+    color: $textarea-icon-color;
+    line-height: $textarea-inner-line-height;
+  }
+
   @include edeep(clear) {
     margin-left: $textarea-icon-margin;
     font-size: $textarea-icon-font-size;

--- a/src/uni_modules/wot-ui/components/wd-textarea/types.ts
+++ b/src/uni_modules/wot-ui/components/wd-textarea/types.ts
@@ -113,6 +113,17 @@ export const textareaProps = {
    */
   prefixIcon: String,
   /**
+   * 图标类名前缀，用法参考 Icon 组件
+   */
+  iconPrefix: String,
+  /**
+   * CSS 图标，用法参考 Icon 组件
+   */
+  cssIcon: {
+    type: [Boolean, String],
+    default: false
+  },
+  /**
    * 是否显示字数限制，需要同时设置maxlength
    */
   showWordLimit: makeBooleanProp(false),

--- a/src/uni_modules/wot-ui/components/wd-textarea/wd-textarea.vue
+++ b/src/uni_modules/wot-ui/components/wd-textarea/wd-textarea.vue
@@ -1,6 +1,7 @@
 <template>
   <view :class="rootClass" :style="customStyle">
     <view class="wd-textarea__body">
+      <wd-icon v-if="prefixIcon" custom-class="wd-textarea__prefix" :name="prefixIcon" :class-prefix="iconPrefix" :css-icon="cssIcon" />
       <textarea
         :class="`wd-textarea__inner ${customTextareaClass}`"
         v-model="inputValue"

--- a/src/uni_modules/wot-ui/components/wd-textarea/wd-textarea.vue
+++ b/src/uni_modules/wot-ui/components/wd-textarea/wd-textarea.vue
@@ -1,7 +1,7 @@
 <template>
   <view :class="rootClass" :style="customStyle">
     <view class="wd-textarea__body">
-      <wd-icon v-if="prefixIcon" custom-class="wd-textarea__prefix" :name="prefixIcon" :class-prefix="iconPrefix" :css-icon="cssIcon" />
+      <wd-icon v-if="hasPrefixIcon" custom-class="wd-textarea__prefix" :name="prefixIcon" :class-prefix="iconPrefix" :css-icon="cssIcon" />
       <textarea
         :class="`wd-textarea__inner ${customTextareaClass}`"
         v-model="inputValue"
@@ -58,7 +58,7 @@ export default {
 <script lang="ts" setup>
 import { computed, onBeforeMount, ref, watch } from 'vue'
 import wdIcon from '../wd-icon/wd-icon.vue'
-import { isDef, pause } from '../../common/util'
+import { isDef, isString, pause } from '../../common/util'
 import { useParent } from '../../composables/useParent'
 import { useTranslate } from '../../composables/useTranslate'
 import { useFormDisabled } from '../../composables/useFormDisabled'
@@ -71,6 +71,8 @@ const props = defineProps(textareaProps)
 const emit = defineEmits(['update:modelValue', 'clear', 'blur', 'focus', 'input', 'keyboardheightchange', 'confirm', 'linechange', 'click'])
 const { parent: formItemValidate } = useParent(FORM_ITEM_VALIDATE_KEY)
 const isDisabled = useFormDisabled(props)
+
+const hasPrefixIcon = computed(() => Boolean(props.prefixIcon || (isString(props.cssIcon) && props.cssIcon)))
 
 const placeholderValue = computed(() => {
   return isDef(props.placeholder) ? props.placeholder : translate('placeholder')

--- a/tests/components/wd-avatar.test.ts
+++ b/tests/components/wd-avatar.test.ts
@@ -66,6 +66,31 @@ describe('WdAvatar', () => {
     expect(wrapper.findComponent(WdIcon).props('name')).toBe(icon)
   })
 
+  test('iconPrefix 和 cssIcon 透传到图标头像', () => {
+    const prefixWrapper = mount(WdAvatar, {
+      props: { icon: 'kehuishouwu', iconPrefix: 'fish' }
+    })
+    expect(prefixWrapper.findComponent(WdIcon).classes()).toContain('fish-kehuishouwu')
+
+    const cssWrapper = mount(WdAvatar, {
+      props: { icon: 'i-carbon-user', cssIcon: true }
+    })
+    expect(cssWrapper.findComponent(WdIcon).classes()).toContain('wd-icon--css')
+    expect(cssWrapper.findComponent(WdIcon).classes()).toContain('i-carbon-user')
+  })
+
+  test('cssIcon 字符串可单独作为图标类名，布尔值不可单独渲染', () => {
+    const stringWrapper = mount(WdAvatar, {
+      props: { cssIcon: 'i-carbon-user' }
+    })
+    expect(stringWrapper.findComponent(WdIcon).classes()).toContain('i-carbon-user')
+
+    const booleanWrapper = mount(WdAvatar, {
+      props: { cssIcon: true }
+    })
+    expect(booleanWrapper.findComponent(WdIcon).exists()).toBe(false)
+  })
+
   // 测试默认插槽
   test('渲染默认插槽', () => {
     const wrapper = mount(WdAvatar, {

--- a/tests/components/wd-cell.test.ts
+++ b/tests/components/wd-cell.test.ts
@@ -59,6 +59,26 @@ describe('WdCell', () => {
     expect(wrapper.find('.wd-cell__prefix').exists()).toBe(true)
   })
 
+  test('cssIcon 透传到前置和后置图标', () => {
+    const wrapper = mount(WdCell, {
+      props: {
+        prefixIcon: 'i-carbon-search',
+        suffixIcon: 'i-carbon-send',
+        cssIcon: true
+      },
+      global: {
+        components: {
+          WdIcon
+        }
+      }
+    })
+    const icons = wrapper.findAllComponents(WdIcon)
+    expect(icons[0].classes()).toContain('wd-icon--css')
+    expect(icons[0].classes()).toContain('i-carbon-search')
+    expect(icons[1].classes()).toContain('wd-icon--css')
+    expect(icons[1].classes()).toContain('i-carbon-send')
+  })
+
   // 测试可点击状态
   test('可点击状态', async () => {
     const wrapper = mount(WdCell, {

--- a/tests/components/wd-empty.test.ts
+++ b/tests/components/wd-empty.test.ts
@@ -81,6 +81,21 @@ describe('WdEmpty', () => {
     expect(wrapper.findComponent(WdIcon).props('name')).toBe(icon)
   })
 
+  test('iconPrefix 和 cssIcon 透传到图标组件', () => {
+    const prefixWrapper = mount(WdEmpty, {
+      props: { icon: 'kehuishouwu', iconPrefix: 'fish' },
+      global: { components: { WdIcon } }
+    })
+    expect(prefixWrapper.findComponent(WdIcon).classes()).toContain('fish-kehuishouwu')
+
+    const cssWrapper = mount(WdEmpty, {
+      props: { icon: 'i-carbon-empty', cssIcon: true },
+      global: { components: { WdIcon } }
+    })
+    expect(cssWrapper.findComponent(WdIcon).classes()).toContain('wd-icon--css')
+    expect(cssWrapper.findComponent(WdIcon).classes()).toContain('i-carbon-empty')
+  })
+
   // 测试自定义图标大小 - 数字
   test('数字类型的图标大小', () => {
     const iconSize = 100

--- a/tests/components/wd-form-item.test.ts
+++ b/tests/components/wd-form-item.test.ts
@@ -182,6 +182,17 @@ describe('WdFormItem', () => {
     expect(cell.props('isLink')).toBe(true)
   })
 
+  test('iconPrefix 和 cssIcon 透传给 wd-cell', () => {
+    const wrapper = mount(WdFormItem, {
+      props: { prefixIcon: 'i-carbon-user', iconPrefix: 'fish', cssIcon: true },
+      global: { components: globalComponents }
+    })
+    const cell = wrapper.findComponent({ name: 'wd-cell' })
+    expect(cell.props('prefixIcon')).toBe('i-carbon-user')
+    expect(cell.props('iconPrefix')).toBe('fish')
+    expect(cell.props('cssIcon')).toBe(true)
+  })
+
   test('validate-trigger 为 change 时，字段变化会触发校验', async () => {
     const schema = {
       validate(model: Record<string, string>) {

--- a/tests/components/wd-grid-item.test.ts
+++ b/tests/components/wd-grid-item.test.ts
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils'
 import WdGridItem from '@/uni_modules/wot-ui/components/wd-grid-item/wd-grid-item.vue'
+import WdIcon from '@/uni_modules/wot-ui/components/wd-icon/wd-icon.vue'
 import { describe, test, expect, vi } from 'vitest'
 
 describe('WdGridItem', () => {
@@ -26,6 +27,27 @@ describe('WdGridItem', () => {
     })
     // 检查 props 是否正确设置，而不是检查 DOM
     expect(wrapper.props('icon')).toBe(icon)
+  })
+
+  test('cssIcon 透传到图标组件', () => {
+    const wrapper = mount(WdGridItem, {
+      props: { icon: 'i-carbon-sun', cssIcon: true }
+    })
+    const icon = wrapper.findComponent(WdIcon)
+    expect(icon.classes()).toContain('wd-icon--css')
+    expect(icon.classes()).toContain('i-carbon-sun')
+  })
+
+  test('cssIcon 字符串可单独作为图标类名，布尔值不可单独渲染', () => {
+    const stringWrapper = mount(WdGridItem, {
+      props: { cssIcon: 'i-carbon-sun' }
+    })
+    expect(stringWrapper.findComponent(WdIcon).classes()).toContain('i-carbon-sun')
+
+    const booleanWrapper = mount(WdGridItem, {
+      props: { cssIcon: true }
+    })
+    expect(booleanWrapper.findComponent(WdIcon).exists()).toBe(false)
   })
 
   // 测试徽标

--- a/tests/components/wd-input.test.ts
+++ b/tests/components/wd-input.test.ts
@@ -176,6 +176,20 @@ describe('输入框组件', () => {
     expect(wrapper.props('suffixIcon')).toBe('arrow-right')
   })
 
+  test('iconPrefix 和 cssIcon 透传到前置后置图标', () => {
+    const wrapper = mount(WdInput, {
+      props: {
+        prefixIcon: 'i-carbon-search',
+        suffixIcon: 'i-carbon-send',
+        iconPrefix: 'fish',
+        cssIcon: true
+      }
+    })
+    expect(wrapper.find('.i-carbon-search').exists()).toBe(true)
+    expect(wrapper.find('.i-carbon-send').exists()).toBe(true)
+    expect(wrapper.findAll('.wd-icon--css').length).toBe(2)
+  })
+
   // 测试错误状态
   test('渲染错误状态', () => {
     const wrapper = mount(WdInput, {

--- a/tests/components/wd-rate.test.ts
+++ b/tests/components/wd-rate.test.ts
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils'
 import WdRate from '@/uni_modules/wot-ui/components/wd-rate/wd-rate.vue'
+import WdIcon from '@/uni_modules/wot-ui/components/wd-icon/wd-icon.vue'
 import { describe, test, expect, vi } from 'vitest'
 import { nextTick } from 'vue'
 
@@ -179,6 +180,22 @@ describe('评分组件', () => {
     // 我们只检查 props 是否正确传递
     expect(vm.icon).toBe(icon)
     expect(vm.activeIcon).toBe(activeIcon)
+  })
+
+  test('iconPrefix 和 cssIcon 透传到评分图标', async () => {
+    const prefixWrapper = mount(WdRate, {
+      props: { modelValue: 0, icon: 'kehuishouwu', iconPrefix: 'fish' }
+    })
+    await nextTick()
+    expect(prefixWrapper.findComponent(WdIcon).classes()).toContain('fish-kehuishouwu')
+
+    const cssWrapper = mount(WdRate, {
+      props: { modelValue: 5, icon: 'i-carbon-star', activeIcon: 'i-carbon-star-filled', cssIcon: true }
+    })
+    await nextTick()
+    const icon = cssWrapper.findComponent(WdIcon)
+    expect(icon.classes()).toContain('wd-icon--css')
+    expect(icon.classes()).toContain('i-carbon-star-filled')
   })
 
   // 测试自定义颜色

--- a/tests/components/wd-sidebar-item.test.ts
+++ b/tests/components/wd-sidebar-item.test.ts
@@ -66,6 +66,35 @@ describe('WdSidebarItem', () => {
     expect(wrapper.find('.custom-icon').exists()).toBe(true)
   })
 
+  test('iconPrefix 和 cssIcon 透传到图标组件', () => {
+    const prefixWrapper = mount(WdSidebarItem, {
+      props: { label: '分类', value: '1', icon: 'kehuishouwu', iconPrefix: 'fish' },
+      global: { components: globalComponents }
+    })
+    expect(prefixWrapper.findComponent(WdIcon).classes()).toContain('fish-kehuishouwu')
+
+    const cssWrapper = mount(WdSidebarItem, {
+      props: { label: '分类', value: '1', icon: 'i-carbon-menu', cssIcon: true },
+      global: { components: globalComponents }
+    })
+    expect(cssWrapper.findComponent(WdIcon).classes()).toContain('wd-icon--css')
+    expect(cssWrapper.findComponent(WdIcon).classes()).toContain('i-carbon-menu')
+  })
+
+  test('cssIcon 字符串可单独作为图标类名，布尔值不可单独渲染', () => {
+    const stringWrapper = mount(WdSidebarItem, {
+      props: { label: '分类', value: '1', cssIcon: 'i-carbon-menu' },
+      global: { components: globalComponents }
+    })
+    expect(stringWrapper.findComponent(WdIcon).classes()).toContain('i-carbon-menu')
+
+    const booleanWrapper = mount(WdSidebarItem, {
+      props: { label: '分类', value: '1', cssIcon: true },
+      global: { components: globalComponents }
+    })
+    expect(booleanWrapper.findComponent(WdIcon).exists()).toBe(false)
+  })
+
   test('与 WdSidebar 集成：选中项添加 wd-sidebar-item--active 类', async () => {
     const wrapper = mount(
       {

--- a/tests/components/wd-slide-verify.test.ts
+++ b/tests/components/wd-slide-verify.test.ts
@@ -39,6 +39,19 @@ describe('wd-slide-verify', () => {
   })
 
   test('iconPrefix 和 cssIcon 透传到滑块图标与成功图标', async () => {
+    const prefixWrapper = mount(WdSlideVerify, {
+      props: {
+        icon: 'i-carbon-arrow-right',
+        iconPrefix: 'fish'
+      }
+    })
+
+    await flushPromises()
+
+    const prefixIcon = prefixWrapper.findComponent(WdIcon)
+    expect(prefixIcon.classes()).toContain('fish-i-carbon-arrow-right')
+    expect(prefixIcon.classes()).not.toContain('wd-icon--css')
+
     const wrapper = mount(WdSlideVerify, {
       props: {
         icon: 'i-carbon-arrow-right',

--- a/tests/components/wd-slide-verify.test.ts
+++ b/tests/components/wd-slide-verify.test.ts
@@ -1,6 +1,7 @@
 import { mount, flushPromises } from '@vue/test-utils'
 import { describe, expect, test, vi } from 'vitest'
 import WdSlideVerify from '@/uni_modules/wot-ui/components/wd-slide-verify/wd-slide-verify.vue'
+import WdIcon from '@/uni_modules/wot-ui/components/wd-icon/wd-icon.vue'
 
 describe('wd-slide-verify', () => {
   test('基本渲染', () => {
@@ -35,6 +36,33 @@ describe('wd-slide-verify', () => {
     const icon = wrapper.findComponent({ name: 'wd-icon' })
     expect(icon.props('name')).toBe('star')
     expect(icon.props('size')).toBe(30)
+  })
+
+  test('iconPrefix 和 cssIcon 透传到滑块图标与成功图标', async () => {
+    const wrapper = mount(WdSlideVerify, {
+      props: {
+        icon: 'i-carbon-arrow-right',
+        successIcon: 'i-carbon-checkmark',
+        iconPrefix: 'fish',
+        cssIcon: true
+      }
+    })
+
+    await flushPromises()
+
+    const icon = wrapper.findComponent(WdIcon)
+    expect(icon.classes()).toContain('wd-icon--css')
+    expect(icon.classes()).toContain('i-carbon-arrow-right')
+
+    const button = wrapper.find('.wd-slide-verify__button')
+    await button.trigger('touchstart', { touches: [{ clientX: 0, clientY: 0 }] })
+    await button.trigger('touchmove', { touches: [{ clientX: 260, clientY: 0 }] })
+    await button.trigger('touchend')
+    await wrapper.vm.$nextTick()
+
+    const successIcon = wrapper.find('.wd-slide-verify__button-icon--success')
+    expect(successIcon.classes()).toContain('wd-icon--css')
+    expect(successIcon.classes()).toContain('i-carbon-checkmark')
   })
 
   test('插槽渲染', () => {

--- a/tests/components/wd-tabbar-item.test.ts
+++ b/tests/components/wd-tabbar-item.test.ts
@@ -39,6 +39,37 @@ describe('WdTabbarItem', () => {
     expect(wrapper.find('.wd-tabbar-item__body-icon').classes()).toContain('is-inactive')
   })
 
+  test('iconPrefix 透传到图标类名前缀', () => {
+    const wrapper = mount(WdTabbarItem, {
+      props: { title: '回收', icon: 'kehuishouwu', iconPrefix: 'fish' }
+    })
+    const icon = wrapper.findComponent(WdIcon)
+    expect(icon.classes()).toContain('fish')
+    expect(icon.classes()).toContain('fish-kehuishouwu')
+  })
+
+  test('cssIcon 透传到图标组件', () => {
+    const wrapper = mount(WdTabbarItem, {
+      props: { title: '首页', icon: 'i-carbon-sun', cssIcon: true }
+    })
+    const icon = wrapper.findComponent(WdIcon)
+    expect(icon.classes()).toContain('wd-icon--css')
+    expect(icon.classes()).toContain('i-carbon-sun')
+    expect(icon.classes()).not.toContain('wd-icon-i-carbon-sun')
+  })
+
+  test('cssIcon 字符串可单独作为图标类名，布尔值不可单独渲染', () => {
+    const stringWrapper = mount(WdTabbarItem, {
+      props: { title: '首页', cssIcon: 'i-carbon-sun' }
+    })
+    expect(stringWrapper.findComponent(WdIcon).classes()).toContain('i-carbon-sun')
+
+    const booleanWrapper = mount(WdTabbarItem, {
+      props: { title: '首页', cssIcon: true }
+    })
+    expect(booleanWrapper.findComponent(WdIcon).exists()).toBe(false)
+  })
+
   test('customClass 追加到根元素', () => {
     const wrapper = mount(WdTabbarItem, {
       props: { title: '首页', customClass: 'my-item' }

--- a/tests/components/wd-tag.test.ts
+++ b/tests/components/wd-tag.test.ts
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils'
 import WdTag from '@/uni_modules/wot-ui/components/wd-tag/wd-tag.vue'
+import WdIcon from '@/uni_modules/wot-ui/components/wd-icon/wd-icon.vue'
 import { describe, test, expect, vi, beforeEach } from 'vitest'
 import { type TagType } from '@/uni_modules/wot-ui/components/wd-tag/types'
 
@@ -232,6 +233,35 @@ describe('WdTag', () => {
     // icon 不添加额外的根节点类，只渲染图标组件
     expect(wrapper.findComponent({ name: 'wd-icon' }).exists()).toBe(true)
     expect(wrapper.findComponent({ name: 'wd-icon' }).props('name')).toBe(icon)
+  })
+
+  test('iconPrefix 和 cssIcon 透传到图标组件', () => {
+    const prefixWrapper = mount(WdTag, {
+      props: { icon: 'kehuishouwu', iconPrefix: 'fish' },
+      slots: { default: '标签' }
+    })
+    expect(prefixWrapper.findComponent(WdIcon).classes()).toContain('fish-kehuishouwu')
+
+    const cssWrapper = mount(WdTag, {
+      props: { icon: 'i-carbon-tag', cssIcon: true },
+      slots: { default: '标签' }
+    })
+    expect(cssWrapper.findComponent(WdIcon).classes()).toContain('wd-icon--css')
+    expect(cssWrapper.findComponent(WdIcon).classes()).toContain('i-carbon-tag')
+  })
+
+  test('cssIcon 字符串可单独作为图标类名，布尔值不可单独渲染', () => {
+    const stringWrapper = mount(WdTag, {
+      props: { cssIcon: 'i-carbon-tag' },
+      slots: { default: '标签' }
+    })
+    expect(stringWrapper.findComponent(WdIcon).classes()).toContain('i-carbon-tag')
+
+    const booleanWrapper = mount(WdTag, {
+      props: { cssIcon: true },
+      slots: { default: '标签' }
+    })
+    expect(booleanWrapper.findComponent(WdIcon).exists()).toBe(false)
   })
 
   // 测试图标插槽

--- a/tests/components/wd-textarea.test.ts
+++ b/tests/components/wd-textarea.test.ts
@@ -166,6 +166,27 @@ describe('WdTextarea', () => {
     expect(icons[1].classes()).not.toContain('wd-icon--css')
   })
 
+  test('cssIcon 字符串可单独渲染前置图标，布尔值不单独渲染', () => {
+    const wrapper = mount(WdTextarea, {
+      props: {
+        cssIcon: 'i-carbon-edit'
+      }
+    })
+
+    const icon = wrapper.findComponent(WdIcon)
+    expect(icon.exists()).toBe(true)
+    expect(icon.classes()).toContain('wd-icon--css')
+    expect(icon.classes()).toContain('i-carbon-edit')
+
+    const booleanWrapper = mount(WdTextarea, {
+      props: {
+        cssIcon: true
+      }
+    })
+
+    expect(booleanWrapper.findComponent(WdIcon).exists()).toBe(false)
+  })
+
   // 测试自动聚焦
   test('自动聚焦', () => {
     const wrapper = mount(WdTextarea, {

--- a/tests/components/wd-textarea.test.ts
+++ b/tests/components/wd-textarea.test.ts
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils'
 import WdTextarea from '@/uni_modules/wot-ui/components/wd-textarea/wd-textarea.vue'
+import WdIcon from '@/uni_modules/wot-ui/components/wd-icon/wd-icon.vue'
 import { describe, test, expect, vi } from 'vitest'
 
 describe('WdTextarea', () => {
@@ -131,6 +132,38 @@ describe('WdTextarea', () => {
     })
     // 只检查组件是否添加了错误状态类
     expect(wrapper.classes()).toContain('is-error')
+  })
+
+  test('prefixIcon 渲染前置图标', () => {
+    const wrapper = mount(WdTextarea, {
+      props: {
+        prefixIcon: 'sound'
+      }
+    })
+
+    const icon = wrapper.findComponent(WdIcon)
+    expect(icon.exists()).toBe(true)
+    expect(icon.props('name')).toBe('sound')
+    expect(wrapper.find('.wd-textarea__prefix').exists()).toBe(true)
+  })
+
+  test('iconPrefix 和 cssIcon 透传到前置图标且不影响清除图标', () => {
+    const wrapper = mount(WdTextarea, {
+      props: {
+        modelValue: 'abc',
+        clearable: true,
+        clearTrigger: 'always',
+        prefixIcon: 'i-carbon-edit',
+        iconPrefix: 'fish',
+        cssIcon: true
+      }
+    })
+
+    const icons = wrapper.findAllComponents(WdIcon)
+    expect(icons[0].classes()).toContain('wd-icon--css')
+    expect(icons[0].classes()).toContain('i-carbon-edit')
+    expect(icons[1].classes()).toContain('wd-icon-close-circle')
+    expect(icons[1].classes()).not.toContain('wd-icon--css')
   })
 
   // 测试自动聚焦


### PR DESCRIPTION
Avatar、Cell、Empty、FormItem、GridItem、Input、Rate、SidebarItem、SlideVerify、TabbarItem、Tag、Textarea

✅ Closes: #100

<!--
请务必阅读[贡献指南](https://github.com/wot-ui/wot-ui/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->



### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [x] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [x] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [x] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

- closes https://github.com/wot-ui/wot-ui/issues/100

### 💡 需求背景和解决方案

本 PR 主要解决部分对外暴露图标属性的组件无法继续透传 `wd-icon` 的 `iconPrefix` / `cssIcon` 能力的问题，使业务侧在使用自定义图标类名前缀或 CSS 图标时，可以通过组件自身的图标属性完成配置。

本次先覆盖一批低风险组件：

- Avatar
- Cell
- Empty
- FormItem
- GridItem
- Input
- Rate
- SidebarItem
- SlideVerify
- TabbarItem
- Tag
- Textarea

最终 API 实现：

- 为上述组件补充 `iconPrefix` / `cssIcon` 相关属性，并透传给内部 `wd-icon`
- `Textarea` 对齐 `Input` 的图标能力，补充 `prefixIcon`、`iconPrefix`、`cssIcon`
- 对存在“仅 cssIcon 字符串即可渲染图标”的组件，增加 `cssIcon` 字符串支持
- 避免将 `cssIcon=true` 误判为独立图标，只有传入字符串类名时才会作为单独图标渲染
- 对 `Cell` 的 `isLink` 内置箭头保持原有逻辑，避免 `cssIcon` 影响内置箭头图标

文档和测试：

- 已补充中文与英文组件文档 API 说明
- 已补充对应组件的单元测试，覆盖 `iconPrefix`、`cssIcon` 透传及边界场景

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 多个组件新增图标相关配置：`icon-prefix`（图标类名前缀）与 `css-icon`（支持 `boolean | string`，默认 `false`）。
* **Bug Fixes**
  * 优化图标渲染判断与透传逻辑，统一在 `icon` 与 `cssIcon` 场景下的展示规则。
* **Documentation**
  * 更新中英文文档，补充新增属性说明与用法示例。
* **Tests**
  * 新增/扩展图标类与 CSS 图标渲染规则的测试用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->