### PR TITLE
fix: 🐛 修复传入日期超出可选范围的滚动位置异常 (#102)

### DIFF
--- a/src/uni_modules/wot-ui/components/wd-calendar-view/monthPanel/month-panel.vue
+++ b/src/uni_modules/wot-ui/components/wd-calendar-view/monthPanel/month-panel.vue
@@ -389,8 +389,16 @@ async function scrollIntoView() {
     activeDate = props.value
   }
 
-  if (!activeDate) {
+  // 当传入日期为空或超出可选范围，修改为当前日期
+  if (!activeDate || activeDate < props.minDate || activeDate > props.maxDate) {
     activeDate = Date.now()
+
+    // 确保 Date.now() 也在可选范围内
+    if (activeDate < props.minDate) {
+      activeDate = props.minDate
+    } else if (activeDate > props.maxDate) {
+      activeDate = props.maxDate
+    }
   }
 
   let top: number = 0


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/wot-ui/wot-ui/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
[https://github.com/wot-ui/wot-ui/issues/102](https://github.com/wot-ui/wot-ui/issues/102)
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
目前当传入的日期超出可选范围时，打开日期范围选择组件的滚动位置会在最底部。

本次调整：
1. 在计算滚动位置函数中增加 当传入日期超出可选范围时，滚动位置以Date.now()进行展示;
2. activeDate赋值为Date.now()后进行再次校验，确保在minDate和maxDate可选范围内;

<!--
1. 要解决的具体问题。
3. 列出最终的 API 实现和用法。
4. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复日历视图滚动定位异常：当当前选中日期为空/无效或落在可选范围之外时，会先回退到当前时间并再限制到最小/最大日期范围内，确保滚动基准始终为有效月份。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->