### PR TITLE
防止事件穿透

### DIFF
--- a/src/uni_modules/wot-ui/components/wd-img/wd-img.vue
+++ b/src/uni_modules/wot-ui/components/wd-img/wd-img.vue
@@ -1,5 +1,5 @@
 <template>
-  <view :class="rootClass" @click="handleClick" :style="rootStyle">
+  <view :class="rootClass" @click.prevent="handleClick" :style="rootStyle">
     <image
       v-if="status !== 'error'"
       :class="`wd-img__image ${customImage}`"


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/wot-ui/wot-ui/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

无

### 💡 需求背景和解决方案

如果`wd-img`的父元素也有点击事件，可以防止查看图片预览时触发父元素的点击事件。


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 优化图片组件的点击行为，点击时将阻止默认操作，同时保留原有的点击处理逻辑。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->