### PR TITLE
feat: ✨ 支持 label 插槽的启用与配置

### DIFF
--- a/docs/component/cell.md
+++ b/docs/component/cell.md
@@ -232,6 +232,7 @@
 | hide-asterisk | 是否隐藏必填星号 | boolean | false |
 | ellipsis | 内容是否超出隐藏显示省略号 | boolean | false |
 | use-title-slot | 是否启用 title 插槽 | boolean | true |
+| use-label-slot | 是否启用 label 插槽 | boolean | true |
 | custom-class | 根节点自定义类名 | string | `''` |
 | custom-style | 根节点自定义样式 | string | `''` |
 | custom-prefix-class | 前置图标自定义样式类 | string | `''` |

--- a/docs/component/cell.md
+++ b/docs/component/cell.md
@@ -233,13 +233,13 @@
 | ellipsis | 内容是否超出隐藏显示省略号 | boolean | false | - |
 | use-title-slot | 是否启用 title 插槽 | boolean | true | - |
 | use-label-slot | 是否启用 label 插槽 | boolean | true | $LOWEST_VERSION$ |
-| custom-class | 根节点自定义类名 | string | `''` |
-| custom-style | 根节点自定义样式 | string | `''` |
-| custom-prefix-class | 前置图标自定义样式类 | string | `''` |
-| custom-suffix-class | 后置图标自定义样式类 | string | `''` |
-| custom-label-class | label 区域自定义样式类 | string | `''` |
-| custom-value-class | value 区域自定义样式类 | string | `''` |
-| custom-title-class | title 区域自定义样式类 | string | `''` |
+| custom-class | 根节点自定义类名 | string | `''` | - |
+| custom-style | 根节点自定义样式 | string | `''` | - |
+| custom-prefix-class | 前置图标自定义样式类 | string | `''` | - |
+| custom-suffix-class | 后置图标自定义样式类 | string | `''` | - |
+| custom-label-class | label 区域自定义样式类 | string | `''` | - |
+| custom-value-class | value 区域自定义样式类 | string | `''` | - |
+| custom-title-class | title 区域自定义样式类 | string | `''` | - |
 
 ## Cell Events
 

--- a/docs/component/cell.md
+++ b/docs/component/cell.md
@@ -205,34 +205,34 @@
 
 ## Cell Attributes
 
-| 参数 | 说明 | 类型 | 默认值 |
-| --- | --- | --- | --- |
-| title | 左侧标题 | string | - |
-| value | 右侧内容 | `string \| number` | `''` |
-| placeholder | 占位符，仅在 value 为空时显示 | string | - |
-| label | 标题下方描述信息 | string | - |
-| prefix-icon | 前置图标名 | string | - |
-| suffix-icon | 后置图标名 | string | - |
-| icon-size | 图标大小 | `string \| number` | - |
-| icon-prefix | 图标类名前缀 | string | - |
-| css-icon | CSS 图标，用法参考 Icon 组件 | `boolean \| string` | `false` |
-| to | 跳转地址 | string | - |
-| replace | 跳转时是否替换当前页面历史 | boolean | false |
-| clickable | 是否开启点击反馈 | boolean | false |
-| is-link | 是否展示右侧箭头并开启点击反馈 | boolean | false |
-| arrow-direction | 箭头方向（仅在 is-link 为 true 时生效），支持 `left / up / down / right` | string | right |
-| size | 单元格大小，支持 `large` | string | - |
-| border | 是否显示内边框，优先级高于 cell-group 同名属性 | boolean | 继承自 CellGroup |
-| title-width | 左侧标题宽度 | `string \| number` | 继承自 CellGroup |
-| center | 是否垂直居中 | boolean | 继承自 CellGroup |
-| layout | 单元格布局方式，支持 `horizontal / vertical` | string | 继承自 CellGroup |
-| value-align | 右侧内容对齐方式，支持 `left / right / center` | string | 继承自 CellGroup |
-| required | 是否显示必填星号 | boolean | false |
-| asterisk-position | 必填星号位置，支持 `start / end` | string | start |
-| hide-asterisk | 是否隐藏必填星号 | boolean | false |
-| ellipsis | 内容是否超出隐藏显示省略号 | boolean | false |
-| use-title-slot | 是否启用 title 插槽 | boolean | true |
-| use-label-slot | 是否启用 label 插槽 | boolean | true |
+| 参数 | 说明 | 类型 | 默认值 | 最低版本 |
+| --- | --- | --- | --- | --- |
+| title | 左侧标题 | string | - | - |
+| value | 右侧内容 | `string \| number` | `''` | - |
+| placeholder | 占位符，仅在 value 为空时显示 | string | - | - |
+| label | 标题下方描述信息 | string | - | - |
+| prefix-icon | 前置图标名 | string | - | - |
+| suffix-icon | 后置图标名 | string | - | - |
+| icon-size | 图标大小 | `string \| number` | - | - |
+| icon-prefix | 图标类名前缀 | string | - | - |
+| css-icon | CSS 图标，用法参考 Icon 组件 | `boolean \| string` | `false` | - |
+| to | 跳转地址 | string | - | - |
+| replace | 跳转时是否替换当前页面历史 | boolean | false | - |
+| clickable | 是否开启点击反馈 | boolean | false | - |
+| is-link | 是否展示右侧箭头并开启点击反馈 | boolean | false | - |
+| arrow-direction | 箭头方向（仅在 is-link 为 true 时生效），支持 `left / up / down / right` | string | right | - |
+| size | 单元格大小，支持 `large` | string | - | - |
+| border | 是否显示内边框，优先级高于 cell-group 同名属性 | boolean | 继承自 CellGroup | - |
+| title-width | 左侧标题宽度 | `string \| number` | 继承自 CellGroup | - |
+| center | 是否垂直居中 | boolean | 继承自 CellGroup | - |
+| layout | 单元格布局方式，支持 `horizontal / vertical` | string | 继承自 CellGroup | - |
+| value-align | 右侧内容对齐方式，支持 `left / right / center` | string | 继承自 CellGroup | - |
+| required | 是否显示必填星号 | boolean | false | - |
+| asterisk-position | 必填星号位置，支持 `start / end` | string | start | - |
+| hide-asterisk | 是否隐藏必填星号 | boolean | false | - |
+| ellipsis | 内容是否超出隐藏显示省略号 | boolean | false | - |
+| use-title-slot | 是否启用 title 插槽 | boolean | true | - |
+| use-label-slot | 是否启用 label 插槽 | boolean | true | $LOWEST_VERSION$ |
 | custom-class | 根节点自定义类名 | string | `''` |
 | custom-style | 根节点自定义样式 | string | `''` |
 | custom-prefix-class | 前置图标自定义样式类 | string | `''` |

--- a/docs/en-US/component/cell.md
+++ b/docs/en-US/component/cell.md
@@ -205,40 +205,41 @@ When both `prefix-icon` and `suffix-icon` use CSS icons, it is recommended to se
 
 ## Cell Attributes
 
-| Parameter | Description | Type | Default Value |
-| --- | --- | --- | --- |
-| title | Left title | string | - |
-| value | Right content | `string \| number` | `''` |
-| placeholder | Placeholder, only displayed when value is empty | string | - |
-| label | Description info below title | string | - |
-| prefix-icon | Leading icon name | string | - |
-| suffix-icon | Trailing icon name | string | - |
-| icon-size | Icon size | `string \| number` | - |
-| icon-prefix | Icon class prefix | string | - |
-| css-icon | CSS icon, see Icon component for usage | `boolean \| string` | `false` |
-| to | Navigation address | string | - |
-| replace | Whether to replace current page history when navigating | boolean | false |
-| clickable | Whether to enable click feedback | boolean | false |
-| is-link | Whether to show right arrow and enable click feedback | boolean | false |
-| arrow-direction | Arrow direction (only effective when is-link is true), supports `left / up / down / right` | string | right |
-| size | Cell size, supports `large` | string | - |
-| border | Whether to show inner border, priority is higher than cell-group same name attribute | boolean | Inherited from CellGroup |
-| title-width | Left title width | `string \| number` | Inherited from CellGroup |
-| center | Whether to center vertically | boolean | Inherited from CellGroup |
-| layout | Cell layout method, supports `horizontal / vertical` | string | Inherited from CellGroup |
-| value-align | Right content alignment, supports `left / right / center` | string | Inherited from CellGroup |
-| required | Whether to show required asterisk | boolean | false |
-| asterisk-position | Required asterisk position, supports `start / end` | string | start |
-| hide-asterisk | Whether to hide required asterisk | boolean | false |
-| ellipsis | Whether to truncate content with ellipsis when exceeding | boolean | false |
-| use-title-slot | Whether to enable title slot | boolean | true |
-| custom-class | Root node custom class name | string | `''` |
-| custom-style | Root node custom style | string | `''` |
-| custom-prefix-class | Leading icon custom style class | string | `''` |
-| custom-suffix-class | Trailing icon custom style class | string | `''` |
-| custom-label-class | Label area custom style class | string | `''` |
-| custom-value-class | Value area custom style class | string | `''` |
-| custom-title-class | Title area custom style class | string | `''` |
+| Parameter | Description | Type | Default Value | Lowest Version |
+| --- | --- | --- | --- | --- |
+| title | Left title | string | - | - |
+| value | Right content | `string \| number` | `''` | - |
+| placeholder | Placeholder, only displayed when value is empty | string | - | - |
+| label | Description info below title | string | - | - |
+| prefix-icon | Leading icon name | string | - | - |
+| suffix-icon | Trailing icon name | string | - | - |
+| icon-size | Icon size | `string \| number` | - | - |
+| icon-prefix | Icon class prefix | string | - | - |
+| css-icon | CSS icon, see Icon component for usage | `boolean \| string` | `false` | - |
+| to | Navigation address | string | - | - |
+| replace | Whether to replace current page history when navigating | boolean | false | - |
+| clickable | Whether to enable click feedback | boolean | false | - |
+| is-link | Whether to show right arrow and enable click feedback | boolean | false | - |
+| arrow-direction | Arrow direction (only effective when is-link is true), supports `left / up / down / right` | string | right | - |
+| size | Cell size, supports `large` | string | - | - |
+| border | Whether to show inner border, priority is higher than cell-group same name attribute | boolean | Inherited from CellGroup | - |
+| title-width | Left title width | `string \| number` | Inherited from CellGroup | - |
+| center | Whether to center vertically | boolean | Inherited from CellGroup | - |
+| layout | Cell layout method, supports `horizontal / vertical` | string | Inherited from CellGroup | - |
+| value-align | Right content alignment, supports `left / right / center` | string | Inherited from CellGroup | - |
+| required | Whether to show required asterisk | boolean | false | - |
+| asterisk-position | Required asterisk position, supports `start / end` | string | start | - |
+| hide-asterisk | Whether to hide required asterisk | boolean | false | - |
+| ellipsis | Whether to truncate content with ellipsis when exceeding | boolean | false | - |
+| use-title-slot | Whether to enable title slot | boolean | true | - |
+| use-label-slot | Whether to enable label slot | boolean | true | $LOWEST_VERSION$ |
+| custom-class | Root node custom class name | string | `''` | - |
+| custom-style | Root node custom style | string | `''` | - |
+| custom-prefix-class | Leading icon custom style class | string | `''` | - |
+| custom-suffix-class | Trailing icon custom style class | string | `''` | - |
+| custom-label-class | Label area custom style class | string | `''` | - |
+| custom-value-class | Value area custom style class | string | `''` | - |
+| custom-title-class | Title area custom style class | string | `''` | - |
 
 ## Cell Events
 

--- a/src/uni_modules/wot-ui/components/wd-cell/types.ts
+++ b/src/uni_modules/wot-ui/components/wd-cell/types.ts
@@ -160,6 +160,12 @@ export const cellProps = {
    */
   useTitleSlot: makeBooleanProp(true),
   /**
+   * 是否启用 label 插槽
+   * 类型: boolean
+   * 默认值: true
+   */
+  useLabelSlot: makeBooleanProp(true),
+  /**
    * 必填星号位置
    * 类型: CellAsteriskPosition
    * 可选值: 'start' | 'end'

--- a/src/uni_modules/wot-ui/components/wd-cell/wd-cell.vue
+++ b/src/uni_modules/wot-ui/components/wd-cell/wd-cell.vue
@@ -25,7 +25,7 @@
           ></wd-icon>
         </slot>
 
-        <view class="wd-cell__title">
+        <view v-if="showTitle" class="wd-cell__title">
           <!--title BEGIN-->
           <slot v-if="useTitleSlot && $slots.title" name="title"></slot>
           <text v-else-if="title" :class="customTitleClass">{{ title }}</text>
@@ -33,9 +33,8 @@
           <!--title END-->
 
           <!--label BEGIN-->
-          <slot v-if="(useLabelSlot && $slots.label)" name="label">
-            <view v-if="label" :class="`wd-cell__label ${customLabelClass}`">{{ label }}</view>
-          </slot>
+          <slot v-if="useLabelSlot && $slots.label" name="label"></slot>
+          <view v-else-if="label" :class="`wd-cell__label ${customLabelClass}`">{{ label }}</view>
           <!--label END-->
         </view>
         <text v-if="required && !hideAsterisk && asteriskPosition === 'end'" class="wd-cell__required">*</text>
@@ -143,6 +142,10 @@ const showLeft = computed(() => {
   const hasLabel = (slots.label && props.useLabelSlot) || props.label
 
   return hasPrefix || hasTitle || hasLabel
+})
+
+const showTitle = computed(() => {
+  return (props.useTitleSlot && slots.title) || props.title || (props.useLabelSlot && slots.label) || props.label
 })
 
 const showPlaceholder = computed(() => {

--- a/src/uni_modules/wot-ui/components/wd-cell/wd-cell.vue
+++ b/src/uni_modules/wot-ui/components/wd-cell/wd-cell.vue
@@ -33,7 +33,7 @@
           <!--title END-->
 
           <!--label BEGIN-->
-          <slot v-if="(useLabelSlot && $slots, label)" name="label">
+          <slot v-if="(useLabelSlot && $slots.label)" name="label">
             <view v-if="label" :class="`wd-cell__label ${customLabelClass}`">{{ label }}</view>
           </slot>
           <!--label END-->

--- a/src/uni_modules/wot-ui/components/wd-cell/wd-cell.vue
+++ b/src/uni_modules/wot-ui/components/wd-cell/wd-cell.vue
@@ -33,7 +33,7 @@
           <!--title END-->
 
           <!--label BEGIN-->
-          <slot name="label">
+          <slot v-if="(useLabelSlot && $slots, label)" name="label">
             <view v-if="label" :class="`wd-cell__label ${customLabelClass}`">{{ label }}</view>
           </slot>
           <!--label END-->
@@ -140,7 +140,7 @@ const showLeft = computed(() => {
   // 有title插槽或title属性
   const hasTitle = (slots.title && props.useTitleSlot) || props.title
   // 有label插槽或label属性
-  const hasLabel = slots.label || props.label
+  const hasLabel = (slots.label && props.useLabelSlot) || props.label
 
   return hasPrefix || hasTitle || hasLabel
 })

--- a/src/uni_modules/wot-ui/components/wd-form-item/wd-form-item.vue
+++ b/src/uni_modules/wot-ui/components/wd-form-item/wd-form-item.vue
@@ -4,6 +4,7 @@
     :custom-style="customStyle"
     :use-title-slot="!!$slots.title"
     :title="title"
+    :use-label-slot="!!$slots.label"
     :label="label"
     :title-width="formItemTitleWidth"
     :prefix-icon="prefixIcon"


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/wot-ui/wot-ui/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [x] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
fixes #106
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增 `wd-cell` 的 `use-label-slot`（boolean）配置，用于控制是否启用左侧 `label` 插槽；默认启用。
- **改进**
  - `wd-cell` 左侧标题展示优化：仅在同时启用 `use-label-slot` 且实际提供 `label` 插槽时渲染插槽内容；否则按 `label` 属性展示默认文案。
  - `wd-form-item` 在外部提供 `label` 插槽时，会正确传递并展示自定义内容。
- **文档**
  - 更新 `wd-cell` 文档：`Cell Attributes` 增加“最低版本”列，并补充 `use-label-slot` 等项说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->