### PR TITLE
feat: ✨ 优化 select-picker 样式，将padding 移动至选择器组件，增大选择器点击区域，方便用户点击

### DIFF
--- a/src/uni_modules/wot-ui/components/wd-select-picker/index.scss
+++ b/src/uni_modules/wot-ui/components/wd-select-picker/index.scss
@@ -7,8 +7,6 @@ $select-picker-bg: var(--wot-select-picker-bg, $filled-oppo) !default;
 $select-picker-loading-opacity: var(--wot-select-picker-loading-opacity, $opacity-disabled) !default;
 // loading 图标尺寸
 $select-picker-loading-icon-size: var(--wot-select-picker-loading-icon-size, $n-48) !default;  
-// 内容区水平内边距
-$select-picker-wrapper-padding-horizontal: var(--wot-select-picker-wrapper-padding-horizontal, $padding-main) !default;
 // 内容区最大高度
 $select-picker-wrapper-max-height: var(--wot-select-picker-wrapper-max-height, $n-375) !default;
 // 选中态文字颜色
@@ -17,8 +15,8 @@ $select-picker-text-active-color: var(--wot-select-picker-text-active-color, $pr
 $select-picker-footer-padding: var(--wot-select-picker-footer-padding, $padding-tight $padding-loose) !default;
 // 确认区域上边框颜色
 $select-picker-footer-border-color: var(--wot-select-picker-footer-border-color, $border-light) !default;
-// 选项内边距
-$select-picker-item-padding: var(--wot-select-picker-item-padding, $padding-extra-loose $padding-zero) !default;
+// 选项左右边距
+$select-picker-item-padding: var(--wot-select-picker-item-padding, $padding-extra-loose $padding-main) !default;
 
 @include b(select-picker) {
   @include e(loading) {
@@ -43,7 +41,6 @@ $select-picker-item-padding: var(--wot-select-picker-item-padding, $padding-extr
   }
 
   @include e(wrapper) {
-    padding: 0 $select-picker-wrapper-padding-horizontal;
     position: relative;
     height: $select-picker-wrapper-max-height;
     box-sizing: border-box;
@@ -61,7 +58,8 @@ $select-picker-item-padding: var(--wot-select-picker-item-padding, $padding-extr
     color: $select-picker-text-active-color;
   }
 
-  @include e(checkbox-item,radio-item) {
+  @include edeep(radio,checkbox) {
+    box-sizing: border-box;
     padding: $select-picker-item-padding;
   }
 

--- a/src/uni_modules/wot-ui/components/wd-select-picker/wd-select-picker.vue
+++ b/src/uni_modules/wot-ui/components/wd-select-picker/wd-select-picker.vue
@@ -38,7 +38,12 @@
             @change="handleChange"
           >
             <view v-for="item in filterColumns" :key="item[valueKey]" :id="'check' + item[valueKey]" class="wd-select-picker__checkbox-item">
-              <wd-checkbox :name="item[valueKey]" :disabled="item.disabled" custom-label-class="wd-select-picker__checkbox-label">
+              <wd-checkbox
+                :name="item[valueKey]"
+                :disabled="item.disabled"
+                custom-class="wd-select-picker__checkbox"
+                custom-label-class="wd-select-picker__checkbox-label"
+              >
                 <block v-if="showHighlightText">
                   <block v-for="text in item[labelKey]" :key="text.label">
                     <text v-if="text.type === 'active'" class="wd-select-picker__text-active">{{ text.label }}</text>
@@ -64,7 +69,12 @@
             @change="handleChange"
           >
             <view v-for="(item, index) in filterColumns" :key="index" :id="'radio' + item[valueKey]" class="wd-select-picker__radio-item">
-              <wd-radio :value="item[valueKey]" :disabled="item.disabled" custom-label-class="wd-select-picker__radio-label">
+              <wd-radio
+                :value="item[valueKey]"
+                :disabled="item.disabled"
+                custom-class="wd-select-picker__radio"
+                custom-label-class="wd-select-picker__radio-label"
+              >
                 <block v-if="showHighlightText">
                   <block v-for="text in item[labelKey]" :key="text.label">
                     <text :class="`${text.type === 'active' ? 'wd-select-picker__text-active' : ''}`">{{ text.label }}</text>

--- a/src/uni_modules/wot-ui/components/wd-select-picker/wd-select-picker.vue
+++ b/src/uni_modules/wot-ui/components/wd-select-picker/wd-select-picker.vue
@@ -26,7 +26,7 @@
         :scroll-with-animation="true"
       >
         <!-- 多选 -->
-        <view v-if="type === 'checkbox' && isArray(selectList)" class="wd-select-picker__checkbox" id="wd-checkbox-group">
+        <view v-if="type === 'checkbox' && isArray(selectList)" id="wd-checkbox-group">
           <wd-checkbox-group
             v-model="selectList"
             :size="selectSize"
@@ -58,7 +58,7 @@
           </wd-checkbox-group>
         </view>
         <!-- 单选 -->
-        <view v-if="type === 'radio' && !isArray(selectList)" class="wd-select-picker__radio" id="wd-radio-group">
+        <view v-if="type === 'radio' && !isArray(selectList)" id="wd-radio-group">
           <wd-radio-group
             v-model="selectList"
             cell


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/wot-ui/wot-ui/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
close #24 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充