### PR TITLE
fix: 🐛Tabs组件添加配置明确v-model绑定name还是index(#120)

### DIFF
--- a/docs/component/tabs.md
+++ b/docs/component/tabs.md
@@ -193,26 +193,27 @@ function handlePopupShow() {
 
 ## Tabs Attributes
 
-| 参数 | 说明 | 类型 | 默认值 |
-| --- | --- | --- | --- |
-| v-model | 当前激活项，可为索引或名称 | `number | string` | `0` |
-| slidable-num | 自动开启滚动的标签数量阈值 | `number` | `6` |
-| map-num | 显示导航地图的标签数量阈值 | `number` | `10` |
-| map-title | 导航地图标题 | `string` | - |
-| sticky | 是否开启粘性布局 | `boolean` | `false` |
-| offset-top | 吸顶偏移量 | `number` | `0` |
-| swipeable | 是否开启手势滑动 | `boolean` | `false` |
-| line-theme | 底部条样式，可选值为 `normal`、`text`、`underline`、`dot` | `TabsLineTheme` | `normal` |
-| line-width | 底部条宽度 | `number | string` | - |
-| line-height | 底部条高度 | `number | string` | - |
-| color | 激活项文字颜色 | `string` | `''` |
-| inactive-color | 非激活项文字颜色 | `string` | `''` |
-| animated | 是否开启切换动画 | `boolean` | `false` |
-| duration | 动画时长，单位毫秒 | `number` | `300` |
-| slidable | 是否开启滚动导航，可选值为 `auto`、`always` | `TabsSlidable` | `auto` |
-| show-scrollbar | 滚动时是否显示滚动条 | `boolean` | `false` |
-| custom-class | 根节点自定义类名 | `string` | `''` |
-| custom-style | 根节点自定义样式 | `string` | `''` |
+| 参数             | 说明                                           | 类型                                       | 默认值      | 最低版本             |
+|----------------|----------------------------------------------|------------------------------------------|----------|------------------|
+| v-model        | 当前激活项，可为索引或名称                                | `number \| string`                       | `0`      |                  |
+| slidable-num   | 自动开启滚动的标签数量阈值                                | `number`                                 | `6`      |                  |
+| map-num        | 显示导航地图的标签数量阈值                                | `number`                                 | `10`     |                  |
+| map-title      | 导航地图标题                                       | `string`                                 | -        |                  |
+| sticky         | 是否开启粘性布局                                     | `boolean`                                | `false`  |                  |
+| offset-top     | 吸顶偏移量                                        | `number`                                 | `0`      |                  |
+| swipeable      | 是否开启手势滑动                                     | `boolean`                                | `false`  |                  |
+| line-theme     | 底部条样式，可选值为 `normal`、`text`、`underline`、`dot` | `TabsLineTheme`                          | `normal` |                  |
+| line-width     | 底部条宽度                                        | `number                       \| string` | -        |                  |
+| line-height    | 底部条高度                                        | `number            \| string`            | -        |                  |
+| color          | 激活项文字颜色                                      | `string`                                 | `''`     |                  |
+| inactive-color | 非激活项文字颜色                                     | `string`                                 | `''`     |                  |
+| animated       | 是否开启切换动画                                     | `boolean`                                | `false`  |                  |
+| duration       | 动画时长，单位毫秒                                    | `number`                                 | `300`    |                  |
+| slidable       | 是否开启滚动导航，可选值为 `auto`、`always`                | `TabsSlidable`                           | `auto`   |                  |
+| show-scrollbar | 滚动时是否显示滚动条                                   | `boolean`                                | `false`  |                  |
+| custom-class   | 根节点自定义类名                                     | `string`                                 | `''`     |                  |
+| custom-style   | 根节点自定义样式                                     | `string`                                 | `''`     |                  |
+| bindUseName    | 使用name绑定v-model                              | `boolean`                                | `false`  | $LOWEST_VERSION$ |
 
 ## Tabs Events
 

--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -2293,5 +2293,6 @@
   "zuo-xia": "lower left",
   "zuo-you-bu-ju": "Horizontal layout",
   "zuo-you-hua-dong": "Slide left and right",
-  "zuo-zhong": "Middle Left"
+  "zuo-zhong": "Middle Left",
+  "shi-yong-name-bang-ding": "use name bind v-model"
 }

--- a/src/locale/zh-CN.json
+++ b/src/locale/zh-CN.json
@@ -2293,5 +2293,6 @@
   "zuo-xia": "左下",
   "zuo-you-bu-ju": "左右布局",
   "zuo-you-hua-dong": "左右滑动",
-  "zuo-zhong": "左中"
+  "zuo-zhong": "左中",
+  "shi-yong-name-bang-ding": "使用name字段绑定v-model"
 }

--- a/src/subPages/tabs/Index.vue
+++ b/src/subPages/tabs/Index.vue
@@ -148,6 +148,14 @@
         </wd-tab>
       </wd-tabs>
     </wd-popup>
+
+    <demo-group transparent>
+      <demo-group-item no-padding :title="$t('shi-yong-name-bang-ding')">
+        <wd-tabs v-model="activeTab" @change="handleChange" sticky :bindUseName="true">
+          <wd-tab v-for="(tab, i) in tabs2" :key="i" :title="tab.label" :name="tab.value" />
+        </wd-tabs>
+      </demo-group-item>
+    </demo-group>
   </page-wraper>
 </template>
 <script lang="ts" setup>
@@ -157,6 +165,15 @@ import { computed, reactive, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 const { t } = useI18n()
 const tabs = ref(['this', 'is', 'a', 'individual', 'example'])
+const tabs2 = [
+  { label: '全部', value: -1, disabled: false },
+  { label: '待兑换', value: 0, disabled: true },
+  { label: '已兑换', value: 1, disabled: false },
+  { label: '已拒绝', value: 3, disabled: false },
+  { label: '已取消', value: 2, disabled: false }
+]
+
+const activeTab = ref(0)
 
 const tab = ref('a')
 

--- a/src/uni_modules/wot-ui/components/wd-tabs/types.ts
+++ b/src/uni_modules/wot-ui/components/wd-tabs/types.ts
@@ -128,7 +128,14 @@ export const tabsProps = {
    * 类型: boolean
    * 默认值: false
    */
-  showScrollbar: makeBooleanProp(false)
+  showScrollbar: makeBooleanProp(false),
+
+  /**
+   * 绑定时使用name绑定 设置为true会通过name绑定 false使用索引绑定
+   * 类型: boolean
+   * 默认值: false
+   */
+  bindUseName: makeBooleanProp(false)
 }
 
 export type TabsExpose = {

--- a/src/uni_modules/wot-ui/components/wd-tabs/wd-tabs.vue
+++ b/src/uni_modules/wot-ui/components/wd-tabs/wd-tabs.vue
@@ -13,7 +13,7 @@
               <scroll-view :scroll-x="innerSlidable" scroll-with-animation :scroll-left="state.scrollLeft">
                 <view class="wd-tabs__nav-container">
                   <view
-                    @click="handleSelect(index)"
+                    @click="handleSelect(index, item)"
                     v-for="(item, index) in children"
                     :key="index"
                     :class="`wd-tabs__nav-item  ${state.activeIndex === index ? 'is-active' : ''} ${item.disabled ? 'is-disabled' : ''}`"
@@ -79,7 +79,7 @@
             <view class="wd-tabs__nav-container">
               <view
                 v-for="(item, index) in children"
-                @click="handleSelect(index)"
+                @click="handleSelect(index, item)"
                 :key="index"
                 :class="`wd-tabs__nav-item ${state.activeIndex === index ? 'is-active' : ''} ${item.disabled ? 'is-disabled' : ''}`"
                 :style="getTabItemStyle(index)"
@@ -405,12 +405,24 @@ async function updateLineStyle(animation: boolean = true) {
 function setActiveTab() {
   if (!state.inited) return
   const name = getTabName(children[state.activeIndex], state.activeIndex)
-  if (name !== props.modelValue) {
-    emit('change', {
-      index: state.activeIndex,
-      name: name
-    })
-    emit('update:modelValue', name)
+  if (props.bindUseName) {
+    // 如果使用name绑定
+    if (name !== props.modelValue) {
+      emit('change', {
+        index: state.activeIndex,
+        name: name
+      })
+      emit('update:modelValue', name)
+    }
+  } else {
+    // 使用index绑定
+    if (state.activeIndex !== props.modelValue) {
+      emit('change', {
+        index: state.activeIndex,
+        name: name
+      })
+      emit('update:modelValue', state.activeIndex)
+    }
   }
 }
 
@@ -437,8 +449,9 @@ function scrollIntoView() {
 /**
  * 单击 tab 的处理
  * @param index 索引
+ * @param item 当前点击的tabItem数据
  */
-function handleSelect(index: number) {
+function handleSelect(index: number, item: any) {
   if (index === undefined) return
   const { disabled } = children[index]
   const name = getTabName(children[index], index)
@@ -451,7 +464,13 @@ function handleSelect(index: number) {
     return
   }
   state.mapShow && toggleMap()
-  setActive(index)
+  // 如果使用name进行绑定走该逻辑
+  if (props.bindUseName) {
+    setActive(item.name)
+  } else {
+    setActive(index)
+  }
+
   emit('click', {
     index,
     name
@@ -483,19 +502,25 @@ function onTouchEnd() {
  * @param {number | string} value 绑定值
  */
 function getActiveIndex(value: number | string) {
-  // name代表的索引超过了children长度的边界，自动用0兜底
-  if (isNumber(value) && value >= children.length) {
-    // eslint-disable-next-line prettier/prettier
-    console.error('[wot ui] warning(wd-tabs): the type of tabs\' value is Number shouldn\'t be less than its children')
-    value = 0
-  }
-  // 如果是字符串直接匹配，匹配不到用0兜底
-  if (isString(value)) {
-    const index = children.findIndex((item) => item.name === value)
-    value = index === -1 ? 0 : index
-  }
+  // 默认兜底index
+  let activeIndex = 0
 
-  return value
+  // 如果使用name进行绑定走该逻辑
+  if (props.bindUseName) {
+    const index = children.findIndex((item) => item.name === value)
+    activeIndex = index === -1 ? 0 : index
+  } else {
+    if (isNumber(value)) {
+      if (value >= children.length) {
+        // eslint-disable-next-line prettier/prettier
+        console.error('[wot ui] warning(wd-tabs): the type of tabs\' value is Number shouldn\'t be less than its children')
+        activeIndex = 0
+      } else {
+        activeIndex = value
+      }
+    }
+  }
+  return activeIndex
 }
 
 defineExpose<TabsExpose>({


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/wot-ui/wot-ui/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
close #120 
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
解决使用对象tabs中name使用number类型 作为name时造成的切换混乱

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ x] 文档已补充或无须补充
- [ x] 代码演示已提供或无须提供
- [ x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * Tabs 组件新增按名称（`name`）绑定当前选项的能力，也支持继续按索引绑定。
  * 新增示例，展示名称绑定、禁用选项及吸顶效果。

* **文档**
  * 完善 Tabs 属性说明，补充最低支持版本、类型、默认值及新增属性信息。

* **国际化**
  * 新增中英文“使用名称绑定”相关文案。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->