### PR TITLE
refactor: ♻️  修复支付宝小程序渲染、导出及性能问题

### DIFF
--- a/src/subPages/qrCode/Index.vue
+++ b/src/subPages/qrCode/Index.vue
@@ -101,13 +101,14 @@
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { QrCodeInstance } from '@/uni_modules/wot-ui/components/wd-qr-code/types'
+import blackMao from '../img/black_mao_1.png'
 
 const { t } = useI18n()
 
 const qrCodeRef = ref<QrCodeInstance>()
 const imgSrc = ref('')
 
-const logoUrl = 'https://img.yzcdn.cn/vant/cat.jpeg'
+const logoUrl = blackMao
 
 async function handleExport() {
   try {

--- a/src/uni_modules/wot-ui/components/wd-qr-code/wd-qr-code.vue
+++ b/src/uni_modules/wot-ui/components/wd-qr-code/wd-qr-code.vue
@@ -4,7 +4,7 @@
     <canvas type="2d" :id="canvasId" :style="canvasStyle" />
     <!-- #endif -->
     <!-- #ifndef MP-WEIXIN -->
-    <canvas :canvas-id="canvasId" :style="canvasStyle" />
+    <canvas :id="canvasId" :canvas-id="canvasId" :width="canvasSize" :height="canvasSize" :style="canvasStyle" />
     <!-- #endif -->
   </view>
 </template>
@@ -23,8 +23,8 @@ export default {
 </script>
 
 <script lang="ts" setup>
-import { computed, getCurrentInstance, nextTick, onMounted, ref, toRaw, watch } from 'vue'
-import { addUnit, uuid } from '../../common/util'
+import { computed, getCurrentInstance, nextTick, onBeforeMount, onMounted, ref, toRaw, watch } from 'vue'
+import { addUnit, getSystemInfo, uuid } from '../../common/util'
 import { canvas2dAdapter } from '../../common/canvasHelper'
 import { generateQRCode, QRErrorCorrectLevel } from './qrcode'
 import { qrCodeProps, type QrCodeExpose } from './types'
@@ -35,7 +35,7 @@ const emit = defineEmits<{
   error: [error: unknown]
 }>()
 
-const instance = getCurrentInstance()
+const { proxy } = getCurrentInstance() as any
 const rootClass = computed(() => `wd-qr-code ${props.customClass}`)
 const canvasStyle = computed(() => ({
   width: addUnit(props.size),
@@ -48,6 +48,13 @@ const canvasCtx = ref<UniApp.CanvasContext | null>(null)
 const pixelRatio = ref(1)
 const isCanvasReady = ref(false)
 let drawTask: Promise<void> = Promise.resolve()
+const canvasSize = computed(() => {
+  let size = props.size
+  // #ifdef MP-ALIPAY
+  size *= pixelRatio.value
+  // #endif
+  return size
+})
 
 watch(
   [
@@ -72,13 +79,24 @@ watch(
     () => props.logoBorderWidth,
     () => props.backgroundImage
   ],
-  () => {
+  (values, oldValues) => {
     if (isCanvasReady.value) {
+      // #ifdef MP-ALIPAY
+      if (values[1] !== oldValues[1]) {
+        canvasCtx.value = null
+      }
+      // #endif
       requestDraw()
     }
   },
-  { deep: true }
+  { deep: true, flush: 'post' }
 )
+
+onBeforeMount(() => {
+  // #ifdef MP-ALIPAY
+  pixelRatio.value = getSystemInfo().pixelRatio || 1
+  // #endif
+})
 
 onMounted(() => {
   nextTick(() => {
@@ -90,7 +108,7 @@ function initCanvas() {
   // #ifdef MP-WEIXIN
   uni
     .createSelectorQuery()
-    .in(instance)
+    .in(proxy)
     .select(`#${canvasId.value}`)
     .node((res) => {
       if (!res?.node) {
@@ -136,7 +154,11 @@ async function draw() {
   let ctx = canvasCtx.value
   // #ifndef MP-WEIXIN
   if (!ctx) {
-    ctx = uni.createCanvasContext(canvasId.value, instance)
+    const alipay = (globalThis as any).my
+    ctx = alipay?.createCanvasContext ? alipay.createCanvasContext(canvasId.value) : uni.createCanvasContext(canvasId.value, proxy)
+    // #ifdef MP-ALIPAY
+    ctx?.scale(pixelRatio.value, pixelRatio.value)
+    // #endif
     canvasCtx.value = ctx
   }
   // #endif
@@ -148,7 +170,7 @@ async function draw() {
 
   try {
     ctx.clearRect(0, 0, props.size, props.size)
-    ctx.fillStyle = props.colorLight
+    ctx.setFillStyle(props.colorLight)
     ctx.fillRect(0, 0, props.size, props.size)
 
     if (!props.text) {
@@ -180,57 +202,70 @@ async function draw() {
 
     if (props.enableGradient) {
       const gradient = createGradient(ctx)
-      ctx.fillStyle = gradient as unknown as string
+      ctx.setFillStyle(gradient)
     } else {
-      ctx.fillStyle = props.colorDark
+      ctx.setFillStyle(props.colorDark)
     }
 
     const hasModule = (row: number, col: number) => {
       return row >= 0 && row < modules.length && col >= 0 && col < modules[row].length && modules[row][col]
     }
 
-    for (let row = 0; row < modules.length; row++) {
-      for (let col = 0; col < modules[row].length; col++) {
-        if (!modules[row][col]) continue
+    if (props.dotType === 'square' && props.dotScale === 1) {
+      drawSquareModules(ctx, modules, tileW, tileH)
+    } else {
+      const shouldBatchPath = props.dotType !== 'square'
+      if (shouldBatchPath) {
+        ctx.beginPath()
+      }
 
-        const x = Math.ceil(col * tileW) + props.margin
-        const y = Math.ceil(row * tileH) + props.margin
-        const width = Math.ceil((col + 1) * tileW) - Math.ceil(col * tileW)
-        const height = Math.ceil((row + 1) * tileH) - Math.ceil(row * tileH)
-        const scaledWidth = width * props.dotScale
-        const scaledHeight = height * props.dotScale
-        const scaledX = x + (width - scaledWidth) / 2
-        const scaledY = y + (height - scaledHeight) / 2
+      for (let row = 0; row < modules.length; row++) {
+        for (let col = 0; col < modules[row].length; col++) {
+          if (!modules[row][col]) continue
 
-        if (props.dotType === 'dots') {
-          ctx.beginPath()
-          ctx.arc(scaledX + scaledWidth / 2, scaledY + scaledHeight / 2, scaledWidth / 2, 0, Math.PI * 2)
-          ctx.fill()
-          continue
+          const x = Math.ceil(col * tileW) + props.margin
+          const y = Math.ceil(row * tileH) + props.margin
+          const width = Math.ceil((col + 1) * tileW) - Math.ceil(col * tileW)
+          const height = Math.ceil((row + 1) * tileH) - Math.ceil(row * tileH)
+          const scaledWidth = width * props.dotScale
+          const scaledHeight = height * props.dotScale
+          const scaledX = x + (width - scaledWidth) / 2
+          const scaledY = y + (height - scaledHeight) / 2
+
+          if (props.dotType === 'dots') {
+            const centerX = scaledX + scaledWidth / 2
+            const centerY = scaledY + scaledHeight / 2
+            const radius = scaledWidth / 2
+            ctx.moveTo(centerX + radius, centerY)
+            ctx.arc(centerX, centerY, radius, 0, Math.PI * 2)
+            continue
+          }
+
+          if (props.dotType === 'rounded') {
+            drawRoundedRect(ctx, scaledX, scaledY, scaledWidth, scaledHeight, scaledWidth * 0.25, false)
+            continue
+          }
+
+          if (props.dotType === 'liquid') {
+            const radius = scaledWidth * 0.5
+            const top = hasModule(row - 1, col)
+            const bottom = hasModule(row + 1, col)
+            const left = hasModule(row, col - 1)
+            const right = hasModule(row, col + 1)
+            const tl = !top && !left ? radius : 0
+            const tr = !top && !right ? radius : 0
+            const br = !bottom && !right ? radius : 0
+            const bl = !bottom && !left ? radius : 0
+            drawRoundedRect(ctx, scaledX, scaledY, scaledWidth, scaledHeight, [tl, tr, br, bl], false)
+            continue
+          }
+
+          ctx.fillRect(scaledX, scaledY, scaledWidth, scaledHeight)
         }
+      }
 
-        if (props.dotType === 'rounded') {
-          drawRoundedRect(ctx, scaledX, scaledY, scaledWidth, scaledHeight, scaledWidth * 0.25)
-          ctx.fill()
-          continue
-        }
-
-        if (props.dotType === 'liquid') {
-          const radius = scaledWidth * 0.5
-          const top = hasModule(row - 1, col)
-          const bottom = hasModule(row + 1, col)
-          const left = hasModule(row, col - 1)
-          const right = hasModule(row, col + 1)
-          const tl = !top && !left ? radius : 0
-          const tr = !top && !right ? radius : 0
-          const br = !bottom && !right ? radius : 0
-          const bl = !bottom && !left ? radius : 0
-          drawRoundedRect(ctx, scaledX, scaledY, scaledWidth, scaledHeight, [tl, tr, br, bl])
-          ctx.fill()
-          continue
-        }
-
-        ctx.fillRect(scaledX, scaledY, scaledWidth, scaledHeight)
+      if (shouldBatchPath) {
+        ctx.fill()
       }
     }
 
@@ -257,10 +292,10 @@ function flushCanvas(ctx: UniApp.CanvasContext) {
     }
 
     try {
-      ctx.draw(true, done)
+      ctx.draw(false, done)
     } catch (error) {
       void error
-      ctx.draw(true)
+      ctx.draw(false)
     }
 
     // H5 上部分实现不会触发 draw 回调，兜底在下一帧后继续流程。
@@ -335,9 +370,41 @@ function createGradientWithStops(gradient: CanvasGradient) {
   return gradient
 }
 
-function drawRoundedRect(ctx: UniApp.CanvasContext, x: number, y: number, width: number, height: number, radius: number | number[]) {
+function drawSquareModules(ctx: UniApp.CanvasContext, modules: boolean[][], tileW: number, tileH: number) {
+  for (let row = 0; row < modules.length; row++) {
+    let runStart = -1
+    for (let col = 0; col <= modules[row].length; col++) {
+      if (modules[row][col]) {
+        if (runStart === -1) {
+          runStart = col
+        }
+        continue
+      }
+      if (runStart === -1) continue
+
+      const x = Math.ceil(runStart * tileW) + props.margin
+      const y = Math.ceil(row * tileH) + props.margin
+      const width = Math.ceil(col * tileW) - Math.ceil(runStart * tileW)
+      const height = Math.ceil((row + 1) * tileH) - Math.ceil(row * tileH)
+      ctx.fillRect(x, y, width, height)
+      runStart = -1
+    }
+  }
+}
+
+function drawRoundedRect(
+  ctx: UniApp.CanvasContext,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number | number[],
+  shouldBeginPath = true
+) {
   const [tl, tr, br, bl] = Array.isArray(radius) ? radius : [radius, radius, radius, radius]
-  ctx.beginPath()
+  if (shouldBeginPath) {
+    ctx.beginPath()
+  }
   ctx.moveTo(x + tl, y)
   ctx.lineTo(x + width - tr, y)
   ctx.arc(x + width - tr, y + tr, tr, 1.5 * Math.PI, 0)
@@ -366,9 +433,6 @@ async function drawImage(ctx: UniApp.CanvasContext, src: string, x: number, y: n
     await drawImageWithGetImageInfo(ctx, src, x, y, width, height)
   } catch (error) {
     ctx.drawImage(src, x, y, width, height)
-    // #ifndef MP-WEIXIN
-    ctx.draw(true)
-    // #endif
     void error
   }
 }
@@ -393,9 +457,6 @@ function drawImageWithGetImageInfo(ctx: UniApp.CanvasContext, src: string, x: nu
       src,
       success: (res) => {
         ctx.drawImage(res.path, x, y, width, height)
-        // #ifndef MP-WEIXIN
-        ctx.draw(true)
-        // #endif
         resolve()
       },
       fail: reject
@@ -442,9 +503,6 @@ async function drawLogo(ctx: UniApp.CanvasContext) {
     await drawLogoWithGetImageInfo(ctx, logoX, logoY, logoWidth, logoHeight)
   } catch (error) {
     drawLogoContent(ctx, props.logo, logoX, logoY, logoWidth, logoHeight)
-    // #ifndef MP-WEIXIN
-    ctx.draw(true)
-    // #endif
     void error
   }
 }
@@ -474,9 +532,6 @@ function drawLogoWithGetImageInfo(ctx: UniApp.CanvasContext, x: number, y: numbe
       success: (res) => {
         try {
           drawLogoContent(ctx, res.path, x, y, width, height)
-          // #ifndef MP-WEIXIN
-          ctx.draw(true)
-          // #endif
           resolve()
         } catch (error) {
           reject(error)
@@ -501,12 +556,12 @@ function drawLogoContent(ctx: UniApp.CanvasContext, image: any, x: number, y: nu
   if (backgroundColor || borderWidth > 0) {
     drawRoundedRect(ctx, boxX, boxY, boxWidth, boxHeight, radius)
     if (backgroundColor) {
-      ctx.fillStyle = backgroundColor
+      ctx.setFillStyle(backgroundColor)
       ctx.fill()
     }
     if (borderWidth > 0) {
-      ctx.lineWidth = borderWidth
-      ctx.strokeStyle = borderColor
+      ctx.setLineWidth(borderWidth)
+      ctx.setStrokeStyle(borderColor)
       ctx.stroke()
     }
   }
@@ -525,14 +580,19 @@ async function exportImage(): Promise<string> {
   await drawTask
 
   return new Promise((resolve, reject) => {
+    const exportSize = props.size * pixelRatio.value
     const options: UniApp.CanvasToTempFilePathOptions = {
       canvasId: canvasId.value,
-      width: props.size,
-      height: props.size,
-      destWidth: props.size * pixelRatio.value,
-      destHeight: props.size * pixelRatio.value,
+      width: exportSize,
+      height: exportSize,
+      destWidth: exportSize,
+      destHeight: exportSize,
       success: (res) => {
-        resolve(res.tempFilePath)
+        let tempFilePath = res.tempFilePath
+        // #ifdef MP-DINGTALK
+        tempFilePath = (res as any).filePath
+        // #endif
+        resolve(tempFilePath)
       },
       fail: reject
     }
@@ -543,7 +603,11 @@ async function exportImage(): Promise<string> {
     }
     // #endif
 
-    uni.canvasToTempFilePath(options, instance)
+    const exportArgs: [UniApp.CanvasToTempFilePathOptions, any?] = [options]
+    // #ifndef MP-ALIPAY
+    exportArgs.push(proxy)
+    // #endif
+    uni.canvasToTempFilePath(...exportArgs)
   })
 }
 

--- a/tests/components/wd-qr-code.test.ts
+++ b/tests/components/wd-qr-code.test.ts
@@ -25,10 +25,15 @@ function createCanvasContextMock() {
     createLinearGradient: createLinearGradientMock,
     draw: drawMock,
     scale: vi.fn(),
-    fillStyle: '',
-    strokeStyle: '',
-    lineWidth: 0
+    setFillStyle: vi.fn(),
+    setStrokeStyle: vi.fn(),
+    setLineWidth: vi.fn()
   }
+}
+
+function getExpectedCanvasSize(size: number) {
+  const shouldUsePixelRatio = process.env.UNI_PLATFORM === 'mp-alipay'
+  return size * (shouldUsePixelRatio ? uni.getSystemInfoSync().pixelRatio || 1 : 1)
 }
 
 beforeAll(() => {
@@ -36,7 +41,7 @@ beforeAll(() => {
     ...(globalThis as any).uni,
     createCanvasContext: vi.fn(() => createCanvasContextMock()),
     canvasToTempFilePath: vi.fn((options: Record<string, any>) => {
-      options.success?.({ tempFilePath: '/tmp/wd-qr-code.png' })
+      options.success?.({ tempFilePath: '/tmp/wd-qr-code.png', filePath: '/tmp/wd-qr-code.png' })
     }),
     getImageInfo: vi.fn((options: Record<string, any>) => {
       options.success?.({ path: options.src })
@@ -60,7 +65,35 @@ describe('WdQrCode', () => {
     await Promise.resolve()
 
     expect(wrapper.classes()).toContain('wd-qr-code')
-    expect(wrapper.find('canvas').exists()).toBe(true)
+    const canvas = wrapper.find('canvas')
+    expect(canvas.exists()).toBe(true)
+    expect(canvas.attributes('id')).toBeTruthy()
+    expect(canvas.attributes('canvas-id')).toBe(canvas.attributes('id'))
+    const expectedCanvasSize = String(getExpectedCanvasSize(200))
+    expect(canvas.attributes('width')).toBe(expectedCanvasSize)
+    expect(canvas.attributes('height')).toBe(expectedCanvasSize)
+    expect(vi.mocked(uni.createCanvasContext).mock.calls[0][0]).toBe(canvas.attributes('id'))
+    expect(drawMock).toHaveBeenCalledWith(false, expect.any(Function))
+
+    const context = vi.mocked(uni.createCanvasContext).mock.results[0].value as ReturnType<typeof createCanvasContextMock>
+    // 默认方块按连续区间合并绘制，避免支付宝模拟器逐码点传递 Canvas 指令。
+    expect(context.fillRect.mock.calls.length).toBeLessThan(300)
+  })
+
+  test('圆角码点使用单次路径批量填充', async () => {
+    mount(WdQrCode, {
+      props: {
+        text: 'https://wot-ui.cn',
+        dotType: 'rounded'
+      }
+    })
+
+    await Promise.resolve()
+    await Promise.resolve()
+
+    const context = vi.mocked(uni.createCanvasContext).mock.results[0].value as ReturnType<typeof createCanvasContextMock>
+    expect(context.beginPath).toHaveBeenCalledTimes(1)
+    expect(context.fill).toHaveBeenCalledTimes(1)
   })
 
   test('点击时触发 click 事件', async () => {
@@ -84,10 +117,18 @@ describe('WdQrCode', () => {
     })
 
     await Promise.resolve()
+    ;(wrapper.vm as any).$.setupState.pixelRatio = 2
     const tempFilePath = await (wrapper.vm as any).exportImage()
+    const exportOptions = vi.mocked(uni.canvasToTempFilePath).mock.calls[0][0]
 
     expect(tempFilePath).toBe('/tmp/wd-qr-code.png')
     expect(uni.canvasToTempFilePath).toHaveBeenCalled()
+    expect(exportOptions).toMatchObject({
+      width: 400,
+      height: 400,
+      destWidth: 400,
+      destHeight: 400
+    })
     expect(createLinearGradientMock).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/wot-ui/wot-ui/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [x] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

暂无。

### 💡 需求背景和解决方案

#### 需求背景

`wd-qr-code` 在支付宝小程序存在以下问题：

1. Canvas 上下文创建方式不兼容，导致二维码无法正确渲染，并持续输出组件实例属性枚举相关警告。
2. Canvas 尺寸及图片导出未正确处理设备像素比，导致支付宝端导出图片尺寸不正确。
3. 钉钉小程序导出图片时返回字段与其他平台不同。
4. 支付宝模拟器执行大量逐码点 Canvas 指令，多个二维码同时渲染时耗时较长。
5. 二维码 Demo 使用远程 Logo，影响小程序环境下的稳定展示。

#### 解决方案

1. 为非微信平台 Canvas 补充 `id`、`canvas-id`、`width` 和 `height`。
2. 支付宝平台按照设备像素比设置 Canvas backing store，并对绘制上下文进行缩放。
3. 支付宝平台使用原生 Canvas 上下文，避免向原生 API 传递 Vue 组件代理实例。
4. 统一使用小程序 Canvas 支持的 `setFillStyle`、`setStrokeStyle` 和 `setLineWidth`。
5. 将绘制过程合并为一次最终提交，避免重复调用 `draw`。
6. 默认方块码点按照连续区间合并绘制，减少 `fillRect` 指令数量。
7. 圆点、圆角和液化码点统一构建路径后一次填充，降低支付宝模拟器的 JSBridge 调用开销。
8. 导出图片时按照设备像素比设置源尺寸和目标尺寸。
9. 使用条件编译处理钉钉平台导出结果的 `filePath` 字段。
10. Demo Logo 替换为项目内本地图片，避免依赖远程资源。
11. 补充支付宝 DPR、导出尺寸、批量绘制及钉钉返回字段相关测试。

本次改动未新增或调整组件 API，现有 `exportImage()` 使用方式保持不变。

#### 验证情况

- H5 目标测试通过
- 支付宝目标测试通过
- 钉钉目标测试通过
- TypeScript 类型检查通过
- 支付宝小程序构建通过
- 微信小程序构建通过
- 钉钉小程序构建通过
- ESLint 和 `git diff --check` 通过

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 二维码组件优化 Canvas 绘制与像素比处理，提升不同平台上的渲染效果。
  * 支持更高质量的二维码图片导出，并兼容更多平台的文件路径返回格式。
  * 优化方形、圆角及其他样式二维码的绘制表现。

* **问题修复**
  * 二维码示例改用本地 Logo 资源，避免远程图片加载异常。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->