### PR TITLE
fix: 🐛 移除 qr-code 的 CommonJS 导出，避免覆盖 vendor 模块

### DIFF
--- a/src/uni_modules/wot-ui/components/wd-qr-code/qrcode.js
+++ b/src/uni_modules/wot-ui/components/wd-qr-code/qrcode.js
@@ -1117,22 +1117,3 @@ export {
   createQRCodeData,
   generateQRCode
 }
-
-if (typeof module !== 'undefined' && module.exports) {
-  module.exports = {
-    QRCodeModel,
-    QR8bitByte,
-    QRBitBuffer,
-    QRPolynomial,
-    QRRSBlock,
-    QRMath,
-    QRUtil,
-    QRMode,
-    QRErrorCorrectLevel,
-    QRMaskPattern,
-    getTypeNumber,
-    getUTF8Length,
-    createQRCodeData,
-    generateQRCode
-  }
-}

--- a/tests/components/wd-qr-code.test.ts
+++ b/tests/components/wd-qr-code.test.ts
@@ -1,6 +1,9 @@
 import { mount } from '@vue/test-utils'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
 import WdQrCode from '@/uni_modules/wot-ui/components/wd-qr-code/wd-qr-code.vue'
+import { generateQRCode, QRErrorCorrectLevel } from '@/uni_modules/wot-ui/components/wd-qr-code/qrcode.js'
 
 const drawMock = vi.fn()
 const createLinearGradientMock = vi.fn(() => ({
@@ -54,6 +57,22 @@ beforeEach(() => {
 })
 
 describe('WdQrCode', () => {
+  test('二维码算法使用 ESM 命名导出', () => {
+    const result = generateQRCode('https://wot-ui.cn', {
+      errorCorrectLevel: QRErrorCorrectLevel.M
+    })
+
+    expect(result.moduleCount).toBeGreaterThan(0)
+    expect(result.modules).toHaveLength(result.moduleCount)
+    expect(result.errorCorrectLevel).toBe(QRErrorCorrectLevel.M)
+  })
+
+  test('二维码算法不包含 CommonJS 导出', () => {
+    const source = readFileSync(resolve('src/uni_modules/wot-ui/components/wd-qr-code/qrcode.js'), 'utf8')
+
+    expect(source).not.toMatch(/\bmodule\.exports\b/)
+  })
+
   test('基本渲染', async () => {
     const wrapper = mount(WdQrCode, {
       props: {


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

暂无。

### 💡 需求背景和解决方案

通过 npm 方式在微信小程序中使用 `wd-qr-code` 时，Rollup 会将二维码算法模块合并到 `common/vendor.js`。

原 `qrcode.js` 同时包含 ESM 导出和 CommonJS `module.exports`。微信小程序运行时执行 `module.exports = {...}` 后，会覆盖整个 vendor 导出对象，导致 Pinia 等模块的导出丢失，最终出现以下错误：

```text
common_vendor.defineStore is not a function
```

本次修改：

1. 删除 `qrcode.js` 中冗余的 CommonJS 导出，统一使用 ESM 命名导出。
2. 增加二维码算法 ESM 导出测试。
3. 增加模块格式回归测试，防止后续重新引入 `module.exports`。

本次修改不涉及组件 API、TypeScript 定义、文档、样式或交互变更。

已完成以下验证：

- `pnpm type-check`
- `pnpm build:lib`
- `pnpm build:h5`
- `pnpm build:mp-weixin`
- `pnpm build:mp-alipay`
- `pnpm build:app`
- H5 目标测试 6/6 通过
- 使用本地 npm tarball 在干净 consumer 中安装并构建微信小程序
- 构建后的 `common/vendor.js` 不再包含二维码模块的 `module.exports`
- 微信开发者工具中二维码正常渲染，`defineStore` 错误消失

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 优化二维码模块的导出兼容性，确保使用 ES 模块方式正常加载。
  * 修复可能因 CommonJS 导出代码导致的二维码功能运行问题。
* **测试**
  * 新增二维码生成结果有效性验证。
  * 增加模块导出格式检查，提升功能稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->