### PR TITLE
fix: 🐛 修复 H5 端二维码导出图片模糊问题

### DIFF
--- a/src/uni_modules/wot-ui/components/wd-qr-code/wd-qr-code.vue
+++ b/src/uni_modules/wot-ui/components/wd-qr-code/wd-qr-code.vue
@@ -93,7 +93,7 @@ watch(
 )
 
 onBeforeMount(() => {
-  // #ifdef MP-ALIPAY
+  // #ifdef H5 || MP-ALIPAY
   pixelRatio.value = getSystemInfo().pixelRatio || 1
   // #endif
 })
@@ -581,10 +581,14 @@ async function exportImage(): Promise<string> {
 
   return new Promise((resolve, reject) => {
     const exportSize = props.size * pixelRatio.value
+    let sourceSize = exportSize
+    // #ifdef H5
+    sourceSize = props.size
+    // #endif
     const options: UniApp.CanvasToTempFilePathOptions = {
       canvasId: canvasId.value,
-      width: exportSize,
-      height: exportSize,
+      width: sourceSize,
+      height: sourceSize,
       destWidth: exportSize,
       destHeight: exportSize,
       success: (res) => {

--- a/tests/components/wd-qr-code.test.ts
+++ b/tests/components/wd-qr-code.test.ts
@@ -351,15 +351,14 @@ describe('WdQrCode', () => {
     })
 
     await Promise.resolve()
-    ;(wrapper.vm as any).$.setupState.pixelRatio = 2
     const tempFilePath = await (wrapper.vm as any).exportImage()
     const exportOptions = vi.mocked(uni.canvasToTempFilePath).mock.calls[0][0]
 
     expect(tempFilePath).toBe('/tmp/wd-qr-code.png')
     expect(uni.canvasToTempFilePath).toHaveBeenCalled()
     expect(exportOptions).toMatchObject({
-      width: 400,
-      height: 400,
+      width: 200,
+      height: 200,
       destWidth: 400,
       destHeight: 400
     })


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/wot-ui/wot-ui/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

暂无。

### 💡 需求背景和解决方案

`qr-code` 组件在 H5 端导出图片时未获取设备像素比，导致高分屏设备上仍按照组件逻辑尺寸导出图片，下载或预览时画质较为模糊。

本次修改：

1. H5 端初始化时获取设备的 `pixelRatio`。
2. 导出时使用组件逻辑尺寸作为 Canvas 源裁剪尺寸。
3. 根据逻辑尺寸和 `pixelRatio` 计算目标图片尺寸，提升高分屏设备上的导出画质。
4. 更新单元测试，通过模拟真实 DPR 初始化流程验证 H5 导出尺寸。
5. 不新增或修改组件公开 API，不影响组件页面显示尺寸。

验证结果：

- `wd-qr-code` 组件 76 条测试全部通过。
- `pnpm type-check` 通过。
- ESLint 检查通过。

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化 H5 和支付宝小程序中的二维码图片导出，确保源画布与目标图片尺寸正确适配设备像素比。
  * 改善高分辨率设备上的二维码导出效果，避免尺寸异常或图片模糊。

* **Tests**
  * 更新二维码导出相关测试，覆盖源尺寸与目标尺寸的正确处理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->