### PR TITLE
fix: 🐛 修复 Slider 组件中图标组件未导入问题

### DIFF
--- a/src/uni_modules/wot-ui/components/wd-slider/wd-slider.vue
+++ b/src/uni_modules/wot-ui/components/wd-slider/wd-slider.vue
@@ -88,6 +88,7 @@ export default {
 
 <script lang="ts" setup>
 import { computed, type CSSProperties, getCurrentInstance, onMounted, ref, watch } from 'vue'
+import wdIcon from '../wd-icon/wd-icon.vue'
 import { deepClone, getRect, isArray, isDef, isEqual, objToStyle, uuid } from '../../common/util'
 import { useFormDisabled } from '../../composables/useFormDisabled'
 import { useTouch } from '../../composables/useTouch'


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

无。

### 💡 需求背景和解决方案

`wd-slider` 组件的滑块按钮使用了 `wd-icon` 展示图标，但组件源码中缺少对 `wd-icon` 的导入，可能导致图标组件无法被正确解析。

本次改动在 `wd-slider` 中补充 `wd-icon` 的显式导入，不涉及 API、样式及交互变更。

同时对全部组件进行了导入遗漏检查，未发现其他同类问题。

已完成以下验证：

- 全组件目录 ESLint 检查通过
- `pnpm type-check` 检查通过
- `git diff --check` 检查通过

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 修复滑块组件图标引用问题，确保滑块图标能够正常显示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->