### PR TITLE
fix: 🐛 修复 Dialog 组件内置图标样式权重不足的问题

### DIFF
--- a/src/uni_modules/wot-ui/components/wd-dialog/index.scss
+++ b/src/uni_modules/wot-ui/components/wd-dialog/index.scss
@@ -248,9 +248,9 @@ $dialog-action-text-border: var(--wot-dialog-action-text-border, $stroke-light) 
     display: block;
   }
 
-  @include e(icon) {
+  @include edeep(icon) {
     font-size: $dialog-icon-size;
-    line-height: $dialog-icon-size;
+    line-height: 1;
     margin: 0 auto;
     margin-bottom: $dialog-icon-margin-bottom;
     color: $dialog-primary-color;
@@ -272,7 +272,7 @@ $dialog-action-text-border: var(--wot-dialog-action-text-border, $stroke-light) 
     }
   }
 
-  @include e(close) {
+  @include edeep(close) {
     position: absolute;
     top: $dialog-close-icon-top;
     right: $dialog-close-icon-right;

--- a/src/uni_modules/wot-ui/components/wd-notify/index.scss
+++ b/src/uni_modules/wot-ui/components/wd-notify/index.scss
@@ -93,13 +93,13 @@ $notify-types: ("primary": ("bg": $notify-primary-bg,
     }
   }
 
-  @include e(prefix) {
+  @include edeep(prefix) {
     font-size: $notify-icon-size;
     margin-right: $notify-icon-spacing;
     flex: 0 0 auto;
   }
 
-  @include e(close) {
+  @include edeep(close) {
     font-size: $notify-icon-size;
     margin-left: $notify-icon-spacing;
     flex: 0 0 auto;

--- a/src/uni_modules/wot-ui/components/wd-upload/index.scss
+++ b/src/uni_modules/wot-ui/components/wd-upload/index.scss
@@ -134,7 +134,7 @@ $upload-row-spacing: var(--wot-upload-row-spacing, $spacing-tight) !default;
     background-color: $upload-evoke-bg;
   }
 
-  @include e(video-icon, file-icon) {
+  @include edeep(video-icon, file-icon) {
     font-size: $upload-cover-icon-size;
   }
 


### PR DESCRIPTION

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

无。

### 💡 需求背景和解决方案

在微信小程序中，组件内置图标的业务样式与 `wd-icon` 通用样式可能具有相同的选择器权重。当 `wd-icon.wxss` 后加载时，业务组件设置的图标尺寸会被通用的 `14px` 字号覆盖。

本次将以下图标样式由 `e` 调整为 `edeep`：

- Dialog 内置状态图标及关闭图标
- Notify 前置图标及关闭图标
- Upload 文件图标及视频图标

微信小程序构建后会生成带组件父级的选择器，例如：

```css
.wd-dialog .wd-dialog__icon
.wd-notify .wd-notify__prefix
.wd-upload .wd-upload__file-icon
```

这些选择器的权重高于 `.wd-icon`，不再依赖 WXSS 加载顺序。

同时将 Dialog 内置图标的 `line-height` 调整为 `1`，使其能够随默认字号或 `iconProps.size` 自定义字号同步变化。

验证结果：

- H5 相关组件测试通过，共 73 个用例
- 微信小程序 Dialog、Notify 测试通过，共 37 个用例
- TypeScript 类型检查通过
- 微信小程序构建通过
- 已检查构建产物，不再存在使用单 class 覆盖 `wd-icon` 尺寸的业务选择器

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **样式优化**
  - 优化对话框、通知和上传组件的图标、关闭按钮及相关元素样式。
  - 改善组件在不同使用场景下的样式兼容性与显示效果。
  - 统一部分图标的行高表现。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->