### PR TITLE
fix: 🐛 修复 InputNumber 加减按钮点击事件冒泡的问题

### DIFF
--- a/src/uni_modules/wot-ui/components/wd-input-number/wd-input-number.vue
+++ b/src/uni_modules/wot-ui/components/wd-input-number/wd-input-number.vue
@@ -8,7 +8,7 @@
     <!-- 减号按钮 -->
     <view
       :class="`wd-input-number__action wd-input-number__sub ${minDisabled || disableMinus ? 'is-disabled' : ''}`"
-      @click="handleClick('sub')"
+      @click.stop="handleClick('sub')"
       @touchstart="handleTouchStart('sub')"
       @touchend.stop="handleTouchEnd"
     >
@@ -33,7 +33,7 @@
     <!-- 加号按钮 -->
     <view
       :class="`wd-input-number__action wd-input-number__add ${maxDisabled || disablePlus ? 'is-disabled' : ''}`"
-      @click="handleClick('add')"
+      @click.stop="handleClick('add')"
       @touchstart="handleTouchStart('add')"
       @touchend.stop="handleTouchEnd"
     >

--- a/tests/components/wd-input-number.test.ts
+++ b/tests/components/wd-input-number.test.ts
@@ -110,6 +110,31 @@ describe('WdInputNumber', () => {
     expect(wrapper.findAll('.wd-input-number__action').length).toBe(2)
   })
 
+  test('点击加减按钮不会触发父容器点击事件', async () => {
+    const parentClick = vi.fn()
+    const WrapperComponent = defineComponent({
+      components: { WdInputNumber },
+      setup() {
+        const value = ref(1)
+        return { parentClick, value }
+      },
+      template: `
+        <view @click="parentClick">
+          <WdInputNumber v-model="value" />
+        </view>
+      `
+    })
+    const wrapper = mount(WrapperComponent)
+    const actionButtons = wrapper.findAll('.wd-input-number__action')
+
+    await actionButtons[1].trigger('click')
+    expect(wrapper.vm.value).toBe(2)
+
+    await actionButtons[0].trigger('click')
+    expect(wrapper.vm.value).toBe(1)
+    expect(parentClick).not.toHaveBeenCalled()
+  })
+
   // 测试输入值
   test('显示正确的值', async () => {
     const wrapper = createWrapper({}, 5)


### PR DESCRIPTION
✅ Closes: #133

<!--
请务必阅读[贡献指南](https://github.com/wot-ui/wot-ui/blob/master/.github/CONTRIBUTING.md)
-->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

- https://github.com/wot-ui/wot-ui/issues/133

### 💡 需求背景和解决方案

`wd-input-number` 放置在绑定了点击事件的父容器中时，点击加号或减号按钮会继续冒泡，导致父容器的点击事件被误触发。

本次为加减按钮的 `click` 事件添加 `.stop` 修饰符，使其行为与中间输入区域保持一致。点击按钮时仅执行数值增减逻辑，不再触发父容器的点击事件。

同时新增回归测试，验证：

1. 点击加减按钮后数值能够正常更新。
2. 点击加减按钮不会触发父容器的点击事件。

本次修复不涉及 API、TypeScript 类型、文档和视觉样式变更，无须提供截图或 GIF。

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复数字输入组件点击加号或减号时触发父容器点击事件的问题。
  * 调整按钮点击行为，确保数值正常增减且事件不会向外冒泡。

* **Tests**
  * 新增测试，验证加减按钮更新数值时不会触发父容器点击回调。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->