### PR TITLE
fix: 🐛 修复 Tag plain 变体自定义边框色

### DIFF
--- a/src/subPages/tag/Index.vue
+++ b/src/subPages/tag/Index.vue
@@ -98,6 +98,9 @@
         <wd-tag custom-class="page-tag__space" color="var(--wot-warning-main, #FAA21E)" bg-color="var(--wot-warning-main, #FAA21E)" variant="plain">
           {{ $t('biao-qian-31') }}
         </wd-tag>
+        <wd-tag custom-class="page-tag__space" color="var(--wot-purple-6, #8059F3)" bg-color="var(--wot-cyan-6, #22B8CF)" variant="dashed">
+          {{ $t('biao-qian-31') }}
+        </wd-tag>
       </demo-group-item>
     </demo-group>
 

--- a/src/uni_modules/wot-ui/components/wd-tag/index.scss
+++ b/src/uni_modules/wot-ui/components/wd-tag/index.scss
@@ -289,6 +289,12 @@ $tag-sizes: (
         @include pixelBorderSurround($color,dashed);
       }
 
+      @include when(plain, dashed) {
+        &::after {
+          border-color: inherit;
+        }
+      }
+
       @include when(text) {
         background: transparent;
         color: $color;

--- a/tests/components/wd-tag.test.ts
+++ b/tests/components/wd-tag.test.ts
@@ -193,6 +193,24 @@ describe('WdTag', () => {
     expect(textStyle).toContain('color:')
   })
 
+  test('虚线模式下 bgColor 设置边框颜色', () => {
+    const bgColor = '#0000ff'
+    const wrapper = mount(WdTag, {
+      props: {
+        bgColor,
+        variant: 'dashed'
+      },
+      slots: {
+        default: '标签'
+      }
+    })
+
+    const style = wrapper.attributes('style')
+    expect(wrapper.classes()).toContain('is-dashed')
+    expect(style).not.toContain('background:')
+    expect(style).toContain('border-color:')
+  })
+
   // 测试插槽内容
   test('插槽内容渲染', () => {
     const wrapper = mount(WdTag, {


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [x] 演示代码改进
- [x] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

Fixes #139

### 💡 需求背景和解决方案

`wd-tag` 的 `plain` 和 `dashed` 变体通过 `::after` 伪元素绘制薄边框，而 `bg-color` 只设置在组件根节点的 `border-color` 上，导致伪元素仍使用 type 对应的默认边框色。

本 PR 在各 type 的 `plain/dashed` 样式中让伪元素继承根节点的 `border-color`：

- 传入 `bg-color` 时，薄边框使用自定义颜色。
- 未传入时，继续使用当前 type 的默认颜色。
- 不新增 CSS 变量，不调整 DOM，也不改变现有 API。
- Demo 增加文字色和边框色明显不同的自定义颜色示例。
- 补充 `dashed` 变体的 `bgColor` 回归测试；现有测试继续覆盖 `plain`。

#### 验证

- `pnpm type-check`
- `pnpm exec eslint src/subPages/tag/Index.vue tests/components/wd-tag.test.ts`
- `pnpm test:h5 tests/components/wd-tag.test.ts --run`（26/26 通过）
- `git diff --cached --check`

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充（现有文档已说明 `bg-color` 控制背景色和边框色，API 无变化）
- [x] 代码演示已提供或无须提供（已补充自定义边框色示例）
- [x] TypeScript 定义已补充或无须补充（Props 与类型无变化）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 标签示例新增虚线样式，并支持紫色文字与青色背景的自定义配色。

- **问题修复**
  - 优化纯色和虚线标签的边框显示，使边框颜色正确继承标签颜色。

- **测试**
  - 新增虚线标签自定义颜色的测试，确保样式和颜色配置符合预期。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->