### PR TITLE
fix: 🐛 修复 QRCode 的 web-types 组件名错误

### DIFF
--- a/docs/component/qr-code.md
+++ b/docs/component/qr-code.md
@@ -120,7 +120,7 @@ async function handleExport() {
 }
 ```
 
-## QRCode Attributes
+## QrCode Attributes
 
 | 参数 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
@@ -148,14 +148,14 @@ async function handleExport() {
 | custom-class | 自定义根节点样式类 | `string` | `''` |
 | custom-style | 自定义根节点样式 | `string` | `''` |
 
-## QRCode Events
+## QrCode Events
 
 | 事件名称 | 说明 | 回调参数 |
 | --- | --- | --- |
 | click | 点击组件时触发 | `event: Event` |
 | error | 绘制或导出过程出错时触发 | `error: unknown` |
 
-## QRCode Methods
+## QrCode Methods
 
 | 方法名称 | 说明 | 参数 | 返回值 |
 | --- | --- | --- | --- |

--- a/docs/en-US/component/qr-code.md
+++ b/docs/en-US/component/qr-code.md
@@ -120,7 +120,7 @@ async function handleExport() {
 }
 ```
 
-## QRCode Attributes
+## QrCode Attributes
 
 | Parameter | Description | Type | Default Value |
 | --- | --- | --- | --- |
@@ -148,14 +148,14 @@ async function handleExport() {
 | custom-class | Custom root class name | `string` | `''` |
 | custom-style | Custom root style | `string` | `''` |
 
-## QRCode Events
+## QrCode Events
 
 | Event Name | Description | Callback Parameters |
 | --- | --- | --- |
 | click | Triggered when the component is clicked | `event: Event` |
 | error | Triggered when drawing or exporting fails | `error: unknown` |
 
-## QRCode Methods
+## QrCode Methods
 
 | Method Name | Description | Parameters | Return Value |
 | --- | --- | --- | --- |


### PR DESCRIPTION
✅ Closes: #142

<!--
请务必阅读[贡献指南](https://github.com/wot-ui/wot-ui/blob/master/.github/CONTRIBUTING.md)
-->
<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [x] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

- Closes #142

### 💡 需求背景和解决方案

`web-types.json` 根据组件文档中的 API 标题生成组件名称和组件符号。

二维码组件文档使用了 `QRCode` 作为 API 标题。生成工具在进行 PascalCase 到 kebab-case 的转换时，会将连续大写字母逐个拆分，导致生成的组件名称为 `wd-q-r-code`，使 JetBrains IDE 无法正确识别 `<wd-qr-code>`。

本次将中英文文档中的 API 标题由 `QRCode` 统一调整为 `QrCode`：

- `QRCode Attributes` → `QrCode Attributes`
- `QRCode Events` → `QrCode Events`
- `QRCode Methods` → `QrCode Methods`

重新生成后，`web-types.json` 中的组件信息为：

```json
{
  "name": "wd-qr-code",
  "source": {
    "symbol": "WdQrCode"
  }
}
```

已执行 `pnpm build:web-types`，构建通过，并确认错误的 `wd-q-r-code` 和 `WdQRCode` 不再存在。

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 统一二维码组件文档中属性、事件和方法章节的命名格式。
  * 中文和英文文档同步更新，章节内容保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->