### PR TITLE
fix: 🐛 修复 App 端 root portal 页面跳转报错 (#126)

### DIFF
--- a/src/uni_modules/wot-ui/components/wd-root-portal/wd-root-portal.vue
+++ b/src/uni_modules/wot-ui/components/wd-root-portal/wd-root-portal.vue
@@ -62,15 +62,19 @@ const themeClass = computed(() => {
 <script module="render" lang="renderjs">
 export default {
   mounted() {
-    if (this.$ownerInstance.$el) {
-      (document.querySelector('uni-app') || document.body).appendChild(this.$ownerInstance.$el)
-    }
+    const ownerInstance = this.$ownerInstance
+    if (!ownerInstance || !ownerInstance.$el) return
+
+    const root = document.querySelector('uni-app') || document.body
+    root.appendChild(ownerInstance.$el)
   },
   beforeDestroy() {
     // 清理，将元素移回原位置
-    if (this.$ownerInstance.$el) {
-      (document.querySelector('uni-app') || document.body).removeChild(this.$ownerInstance.$el)
-    }
+    const ownerInstance = this.$ownerInstance
+    if (!ownerInstance || !ownerInstance.$el) return
+
+    const root = document.querySelector('uni-app') || document.body
+    if (ownerInstance.$el.parentNode === root) root.removeChild(ownerInstance.$el)
   }
 }
 </script>


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/wot-ui/wot-ui/blob/master/.github/CONTRIBUTING.md)
-->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

Closes #126

### 💡 需求背景和解决方案

在 uni-app App 端进行 `switchTab`、`navigateTo` 等页面跳转时，`wd-root-portal` 的 renderjs 模块可能在 `$ownerInstance` 尚未初始化的情况下执行 `mounted`，直接访问 `$ownerInstance.$el` 会抛出异常。

本次修改：

1. 在 `mounted` 和 `beforeDestroy` 中增加 `$ownerInstance` 与 `$el` 判空，避免页面生命周期过渡期间访问未初始化实例。
2. 移除节点前检查其父节点是否为目标根节点，避免调用 `removeChild` 时再次抛出异常。
3. 不涉及组件 API、样式和使用方式变更。

验证结果：

- ESLint 校验通过
- TypeScript 类型检查通过
- App 平台构建通过
- `wd-root-portal` 测试 6/6 通过
- 全量测试 1796/1796 通过

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 优化根节点门户组件的挂载与销毁处理。
  * 避免在目标元素或根节点不存在时执行无效操作。
  * 防止错误移除未挂载的元素，提升页面稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->