### PR TITLE
fix: 🐛 修复 Tabs 导航地图长标题溢出

### DIFF
--- a/src/uni_modules/wot-ui/components/wd-tabs/index.scss
+++ b/src/uni_modules/wot-ui/components/wd-tabs/index.scss
@@ -268,6 +268,7 @@ $tabs-map-body-bg: var(--wot-tabs-map-body-bg, $filled-oppo) !default;
 
   @include e(map-nav-item) {
     flex-basis: calc((100% - 2 * $tabs-map-nav-btn-gap) / 3);
+    min-width: 0;
     box-sizing: border-box;
     margin-right: $tabs-map-nav-btn-gap;
     margin-bottom: $tabs-map-nav-btn-gap;


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

Closes #129

### 💡 需求背景和解决方案

Tabs 组件显示导航地图时，如果标签标题过长，地图中的 Flex 子项会受到最小内容宽度限制，导致父容器被撑开，三列布局出现错乱，标题也无法正确显示省略号。

本次在 `.wd-tabs__map-nav-item` 上增加 `min-width: 0`，允许 Flex 子项按照现有的三列宽度正常收缩，使内部已经配置的单行省略样式生效。

本次修改不涉及组件 API、TypeScript 定义及默认行为变更。

修复前效果见 #129，修复后长标题能够正常显示省略号，三列布局保持不变，页面不会产生横向溢出。

验证情况：

- `pnpm test:h5 --run tests/components/wd-tabs.test.ts`：12 个测试全部通过
- `pnpm lint`：通过
- `pnpm type-check`：通过
- `pnpm build:mp-weixin`：通过
- H5 页面视觉验证：长标题省略、三列布局及页面宽度均正常

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **样式**
  * 优化地图模式下导航项的弹性布局，避免内容导致项目宽度被过度撑开。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->