### PR TITLE
fix: 🐛 调整滑动验证示例布局，避免误触侧滑返回

### DIFF
--- a/src/subPages/slideVerify/Index.vue
+++ b/src/subPages/slideVerify/Index.vue
@@ -81,6 +81,11 @@ function handleReset() {
 
 <style lang="scss" scoped>
 .page-slide-verify {
+  :deep(.wd-slide-verify) {
+    width: auto;
+    margin: 0 $spacing-super-loose;
+  }
+
   &__reset-button {
     margin-top: $spacing-super-loose;
   }


### PR DESCRIPTION
✅ Closes: #3

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

- #3

### 💡 需求背景和解决方案

微信小程序 SlideVerify 演示页中的滑块起点距离屏幕左侧较近。在部分支持侧滑返回的设备上，拖动滑块时可能误触页面返回手势，导致页面跟随手势移动。

本次仅调整 SlideVerify 演示页布局：

- 缩窄滑动验证组件并保持水平居中。
- 将滑块起点与屏幕边缘的距离由约 `12px` 增加至约 `32px`。
- 不修改组件默认样式和交互逻辑。
- 不拦截或禁用小程序原生页面返回手势。

调整前效果见 #3 中的截图。

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **样式优化**
  - 优化滑动验证组件的布局样式。
  - 组件宽度将自动适配，并增加左右间距，改善页面显示效果。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->