### PR TITLE
chore: 🚀 通过 symlink 让 Claude Code 复用 AGENTS.md 与 skills

### DIFF
--- a/.agents/skills/generate-scss-variables/SKILL.md
+++ b/.agents/skills/generate-scss-variables/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: generate-scss-variables
 description: 为新组件或新特性快速生成符合设计系统规范的 SCSS 变量定义代码，或检查现有变量是否合规。
-applyTo: "**/*.scss"
+metadata:
+  applyTo: "**/*.scss"
 ---
 
 # SCSS 变量生成与检查技能

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 其他改动（AI 协作配置：让 Claude Code 复用仓库既有的 `AGENTS.md` 与 `.agents/skills/`）

### 🔗 相关 Issue

无，日常协作中发现的问题。

### 💡 需求背景和解决方案

**问题**

仓库目前把 AI 协作规范收在 `AGENTS.md` 与 `.agents/skills/` 下，这是 Codex 等工具的约定路径。但 Claude Code 只会读取 `CLAUDE.md` 与 `.claude/skills/`，所以同一套已经写好的规范在 Claude Code 里完全不生效——用它协作时既读不到 `AGENTS.md` 的核心约束，也调不到那 10 个 skill。

**方案**

不复制副本、不改任何既有内容，只加两个 git symlink（mode `120000`，相对路径）：

| symlink | 指向 |
|---|---|
| `CLAUDE.md` | `AGENTS.md` |
| `.claude/skills` | `../.agents/skills` |

单一事实来源仍然是 `AGENTS.md` 与 `.agents/`，改一处两端同步，不存在双份维护和内容漂移。

顺手统一了一处 frontmatter：`generate-scss-variables/SKILL.md` 把 `applyTo` 写在顶层，而同类的 `generate-theme` 是嵌在 `metadata` 下的；顶层自定义键不符合 skill frontmatter 规范，改为 `metadata.applyTo` 后两者一致，Codex 侧读取不受影响。

**验证**

- Claude Code 实测：symlink 建好后 10 个 skill 全部被正确识别、`CLAUDE.md` 内容加载正常。
- `git show --raw` 确认两条均为 mode `120000`，blob 内容即目标相对路径。
- 另建临时 worktree 做全新 checkout，symlink 正常还原且可穿透读取。
- `lint-staged` 仅匹配 `*.{js,ts,vue}`，本 PR 不触发 lint；未改动任何源码、样式与测试。

**已知限制**

Windows 用户若未开启开发者模式（或 `git config core.symlinks false`），checkout 后 `CLAUDE.md` 会退化为内容是 `AGENTS.md` 的普通文本文件，`.claude/skills` 同理。这不影响 macOS / Linux 与已开启 symlink 支持的 Windows。如果维护者希望把这条限制写进 `.github/CONTRIBUTING.md`，我可以在本 PR 里补上。

**另外**

`.github/agents/` 下 3 个 `*.agent.md` 这次**没有**做 symlink：它们的 `tools:` 用的是 Copilot 的工具名（`vscode/runCommand`、`read/readFile` 等），Claude Code 无法识别，直接链过去会得到一批没有可用工具的代理。要支持需要额外做格式转换，属于另一个话题，本 PR 不涉及。

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充（未改动文档内容；已知限制见上，可按维护者意见补入 CONTRIBUTING）
- [x] 代码演示已提供或无须提供（不涉及组件）
- [x] TypeScript 定义已补充或无须补充（不涉及类型）

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新增功能**
  * 技能现在可自动匹配 SCSS 文件，提升相关开发任务的适配性。
  * 新增统一的技能配置入口，便于不同工具共享技能。
  * 统一项目协作指引的访问入口，保持文档内容一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->