### PR TITLE
fix: 🐛 修复骨架屏动画延迟两秒启动的问题

### DIFF
--- a/src/uni_modules/wot-ui/components/wd-skeleton/index.scss
+++ b/src/uni_modules/wot-ui/components/wd-skeleton/index.scss
@@ -78,14 +78,14 @@ $skeleton-animation-flashed-opacity: var(--wot-skeleton-animation-flashed-opacit
       &::after {
         content: ' ';
         position: absolute;
-        animation: wd-skeleton-gradient 1.5s linear 2s infinite;
+        animation: wd-skeleton-gradient 1.5s linear infinite;
         background: linear-gradient(90deg, transparent, $skeleton-animation-gradient, transparent);
         inset: 0;
       }
     }
 
     &-flashed {
-      animation: wd-skeleton-flashed 2s linear 2s infinite;
+      animation: wd-skeleton-flashed 2s linear infinite;
     }
   }
 


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

暂无。

### 💡 需求背景和解决方案

用户反馈骨架屏开启动画后，需要等待 2 秒才会出现动画效果。

原因是 `gradient` 和 `flashed` 动画的 CSS `animation` 简写中配置了 `2s` 的 `animation-delay`。

本次移除两种动画的首次启动延迟，使骨架屏渲染后立即播放动画，同时保持原有动画周期和效果不变。

本次改动不涉及组件 API、TypeScript 类型及使用方式的调整。

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **样式**
  * 优化骨架屏加载动画，移除初始 2 秒延迟。
  * 骨架屏渐变和闪烁效果将在加载后立即开始，动画时长、方向及其他样式保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->