### PR TITLE
fix: web-types 元数据不再把 v-model 写成属性名，修复 WebStorm 误报

### DIFF
--- a/scripts/build-web-types.ts
+++ b/scripts/build-web-types.ts
@@ -4,6 +4,7 @@ import { version, name } from '../package.json'
 import type { ReAttribute, ReComponentName, ReDocUrl, ReWebTypesSource, ReWebTypesType } from 'components-helper'
 import path from 'path'
 import { generateWebTypes } from './component-helper'
+import { getPureValue, resolvePropName } from './web-types-helper'
 import os from 'os'
 
 // 定义类型映射
@@ -43,19 +44,6 @@ const reWebTypesSource: ReWebTypesSource = (title) => {
   return { symbol }
 }
 
-// 获取纯净值（移除所有反引号和星号以及首尾的单双引号）
-const getPureValue = (value: string) => {
-  return value
-    .replace(/[`*]/g, '')
-    .replace(/^['"]|['"]$/g, '')
-    .trim()
-}
-
-// 移除参数列中的版本标记，避免生成的属性名被 ^(x.y.z) 污染
-const stripVersionMarker = (value: string) => {
-  return value.replace(/\s*\^\(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?\)/g, '').trim()
-}
-
 // 重新定义 WebTypes 类型的函数
 const reWebTypesType: ReWebTypesType = (type) => {
   const _type = getPureValue(type)
@@ -80,27 +68,11 @@ const findModule = (type: string) => {
   return undefined
 }
 
-// 将驼峰写法转换为短横线连接的写法的函数
-const toKebabCase = (str: string) => {
-  return str.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase()
-}
-
 // 重新定义属性名称的函数
 const reAttribute: ReAttribute = (value, key, row, title) => {
   if (title.includes('Attributes')) {
     if (key === '参数') {
-      const normalizedValue = stripVersionMarker(value)
-
-      if (normalizedValue.includes('v-model:')) {
-        const part = normalizedValue.split(/[\s/|]/).find((part) => part.startsWith('v-model:'))
-        if (part) {
-          const suffix = toKebabCase(part.split(':')[1].split(/[\s\W]/)[0])
-          return `v-model:${suffix}`
-        }
-      } else if (normalizedValue.includes('v-model')) {
-        return 'v-model'
-      }
-      return toKebabCase(stripVersionMarker(normalizedValue).replace(/[^\w\s-]/g, ''))
+      return resolvePropName(value)
     } else if (key === '可选值' || key === '默认值') {
       const pureValue = getPureValue(value)
 

--- a/scripts/web-types-helper.ts
+++ b/scripts/web-types-helper.ts
@@ -1,0 +1,83 @@
+/**
+ * 文档表格 → IDE 元数据的纯函数集合。
+ *
+ * 单独成模块是为了让单元测试能直接引用这些函数，
+ * 而不必 import `build-web-types.ts`（那个文件在模块顶层就会真正跑一遍生成流程）。
+ */
+
+// 默认 model 对应的真实 prop 名（Vue 3 的 modelValue）
+export const MODEL_VALUE_PROP = 'model-value'
+
+// 获取纯净值（移除所有反引号和星号以及首尾的单双引号）
+export const getPureValue = (value: string) => {
+  return value
+    .replace(/[`*]/g, '')
+    .replace(/^['"]|['"]$/g, '')
+    .trim()
+}
+
+// 移除参数列中的版本标记，避免生成的属性名被 ^(x.y.z) 污染
+export const stripVersionMarker = (value: string) => {
+  return value.replace(/\s*\^\(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?\)/g, '').trim()
+}
+
+// 将驼峰写法转换为短横线连接的写法的函数
+export const toKebabCase = (str: string) => {
+  return str.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase()
+}
+
+// 清理单个属性名：去掉 markdown 残留符号，并统一为短横线写法
+export const normalizePropName = (alias: string) => {
+  return toKebabCase(alias.replace(/[^\w\s-]/g, '')).trim()
+}
+
+// 按书写顺序逐个别名尝试，取第一个能确定 prop 名的
+function resolveFromAliases(aliases: string[]) {
+  for (const alias of aliases) {
+    // 具名 model：`v-model:car-lang` / `v-model:carLang` → prop 名就是修饰符本身。
+    // 修饰符要整段取，按非单词字符截断会把 car-lang 截成 car、file-list 截成 file
+    const namedModel = alias.match(/^v-model:([\w-]+)$/)
+    if (namedModel) return toKebabCase(namedModel[1])
+
+    // 默认 model：裸 `v-model` → modelValue
+    if (alias === 'v-model') return MODEL_VALUE_PROP
+
+    const propName = normalizePropName(alias)
+    if (propName) return propName
+  }
+
+  return undefined
+}
+
+/**
+ * 从「参数」列解析出组件真实的 prop 名。
+ *
+ * 文档里的写法并不统一，可能是 `v-model`、`v-model / modelValue`、`model-value / v-model`、
+ * `visible / v-model:visible`、`v-model:car-lang` 等多种形式。
+ * IDE 元数据（web-types.json / attributes.json）里必须落成真实 prop 名：
+ * 一旦写成字面量 `v-model`，WebStorm 会把它当成一个「布尔型 HTML 属性」，
+ * 而布尔属性只允许取空串或属性名自身，于是 `v-model="show"` 会被误报
+ * 「show 不是 v-model 的有效值，预期值: v-model」。
+ *
+ * 识别 v-model 依赖精确拼写，所以每个别名都要先过 getPureValue 剥掉 markdown 装饰 ——
+ * 否则 `` `v-model` `` 会被当成普通属性名原样落库，把上面那个 bug 放回去。
+ */
+export const resolvePropName = (value: string) => {
+  // 别名之间用 `/` 或 `|` 分隔，按书写顺序取第一个能确定 prop 名的
+  const aliases = stripVersionMarker(value)
+    .split(/[/|]/)
+    .map((alias) => getPureValue(alias))
+    .filter(Boolean)
+
+  const propName = resolveFromAliases(aliases) ?? normalizePropName(stripVersionMarker(value))
+
+  // 兜底护栏：字面量 v-model 绝不允许落进产物，否则就是回归到本函数要修的那个 bug。
+  // 与其静默发布坏元数据，不如让构建失败并指出该改哪一行文档。
+  if (propName.startsWith('v-model')) {
+    throw new Error(
+      `「参数」列 ${JSON.stringify(value)} 解析出了非法属性名 ${JSON.stringify(propName)}，请改成裸写的 v-model 或 v-model:<完整修饰符>`
+    )
+  }
+
+  return propName
+}

--- a/tests/scripts/web-types-helper.test.ts
+++ b/tests/scripts/web-types-helper.test.ts
@@ -1,0 +1,83 @@
+import { describe, test, expect } from 'vitest'
+import { resolvePropName } from '../../scripts/web-types-helper'
+
+describe('resolvePropName - 文档「参数」列的各种写法', () => {
+  test('裸 v-model 落成 model-value', () => {
+    expect(resolvePropName('v-model')).toBe('model-value')
+  })
+
+  test('v-model / modelValue 落成 model-value', () => {
+    expect(resolvePropName('v-model / modelValue')).toBe('model-value')
+  })
+
+  test('model-value / v-model 落成 model-value（真实名写在前面时不能被丢弃）', () => {
+    expect(resolvePropName('model-value / v-model')).toBe('model-value')
+  })
+
+  test('具名 model 取修饰符本身', () => {
+    expect(resolvePropName('v-model:visible')).toBe('visible')
+    expect(resolvePropName('visible / v-model:visible')).toBe('visible')
+    expect(resolvePropName('value / v-model:value')).toBe('value')
+  })
+
+  test('具名 model 的修饰符含连字符时不能被截断（回归：car-lang 曾被截成 car）', () => {
+    expect(resolvePropName('v-model:car-lang')).toBe('car-lang')
+  })
+
+  test('具名 model 的修饰符含连字符时不能被截断（回归：file-list 曾被截成 file）', () => {
+    expect(resolvePropName('file-list / v-model:file-list')).toBe('file-list')
+  })
+
+  test('驼峰修饰符转成短横线', () => {
+    expect(resolvePropName('v-model:carLang')).toBe('car-lang')
+  })
+
+  test('普通属性名原样透传', () => {
+    expect(resolvePropName('close-on-click-modal')).toBe('close-on-click-modal')
+    expect(resolvePropName('z-index')).toBe('z-index')
+    expect(resolvePropName('title')).toBe('title')
+  })
+
+  test('驼峰普通属性名转成短横线', () => {
+    expect(resolvePropName('customClass')).toBe('custom-class')
+  })
+
+  test('剥掉版本标记后仍能解析出正确 prop 名', () => {
+    expect(resolvePropName('visible ^(1.2.0) / v-model:visible')).toBe('visible')
+    expect(resolvePropName('v-model ^(1.2.0)')).toBe('model-value')
+  })
+})
+
+describe('resolvePropName - markdown 装饰不能让字面量 v-model 复活', () => {
+  test('反引号包裹的 v-model', () => {
+    expect(resolvePropName('`v-model`')).toBe('model-value')
+  })
+
+  test('加粗的 v-model', () => {
+    expect(resolvePropName('**v-model**')).toBe('model-value')
+  })
+
+  test('反引号包裹的具名 model 不能产出 v-modelcar-lang 这种垃圾名', () => {
+    expect(resolvePropName('`v-model:car-lang`')).toBe('car-lang')
+  })
+
+  test('任何合法写法都不允许解析出以 v-model 开头的属性名', () => {
+    const inputs = ['v-model', '`v-model`', '**v-model**', 'v-model:visible', '`v-model:car-lang`', 'v-model / modelValue']
+
+    for (const input of inputs) {
+      expect(resolvePropName(input).startsWith('v-model')).toBe(false)
+    }
+  })
+})
+
+describe('resolvePropName - 兜底护栏', () => {
+  test('无法识别的 v-model 写法直接抛错，而不是静默产出坏属性名', () => {
+    // 修饰符缺失 / 带 directive 修饰符，都不是「参数」列的合法写法
+    expect(() => resolvePropName('v-model:')).toThrow(/非法属性名/)
+    expect(() => resolvePropName('v-model.trim')).toThrow(/非法属性名/)
+  })
+
+  test('抛错信息里带上原始单元格内容，便于定位是哪行文档', () => {
+    expect(() => resolvePropName('v-model.trim')).toThrow(/v-model\.trim/)
+  })
+})


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

Closes #118

### 💡 需求背景和解决方案

#### 要解决的具体问题

在 WebStorm / IDEA 里给带 `v-model` 的组件（`wd-popup`、`wd-action-sheet` 等）绑值时，编辑器会误报：

> `showPopup is not a valid value for v-model. Expected: v-model`

虽然不影响运行，但每个用到 `v-model` 的地方都会亮黄，开发体验很差。

#### 根因

`scripts/build-web-types.ts` 在解析文档「参数」列时，把字面量 `v-model` / `v-model:xxx` 直接当成属性名写进了 `web-types.json` 和 `attributes.json`：

```jsonc
// 修复前 —— wd-popup
{ "name": "v-model", "description": "弹出层是否显示", "type": ["boolean"], "default": "false" }
```

也就是说，元数据里凭空多出了一个名叫 `v-model`、类型为 `boolean` 的属性。IDE 对布尔属性只允许「空串」或「属性名自身」作为取值，于是 `v-model="showPopup"` 里的 `showPopup` 被判为非法 —— 报错信息里那句 `Expected: v-model` 正是这个判定的结果。

IDE 元数据里本该落**组件真实的 prop 名**（`model-value`），`v-model` 是模板语法糖，不是 prop。

顺带还发现一个被这段逻辑掩盖的 bug：具名 model 的修饰符是按非单词字符截断的（`part.split(':')[1].split(/[\s\W]/)[0]`），导致带连字符的修饰符被截短 —— `wd-upload` 的 `file-list` 变成了 `v-model:file`。

#### 解决方案

新增 `resolvePropName()`，从「参数」列解析出真实 prop 名：

| 文档「参数」列写法 | 修复前 | 修复后 |
| --- | --- | --- |
| `v-model` | `v-model` | `model-value` |
| `v-model / modelValue` | `v-model` | `model-value` |
| `model-value / v-model` | `v-model` | `model-value` |
| `visible / v-model:visible` | `v-model:visible` | `visible` |
| `file-list / v-model:file-list` | `v-model:file` ⚠️ | `file-list` |
| `v-model:carLang` | `v-model:car` ⚠️ | `car-lang` |

几个细节：

- **每个别名先过 `getPureValue()` 剥掉 markdown 装饰**再比对。文档里有 `` `v-model` `` 这种带反引号的写法，不剥掉就会被当成普通属性名原样落库，等于把这个 bug 放回去。
- **修饰符整段取** (`/^v-model:([\w-]+)$/`)，不再按非单词字符截断，修掉上面 `file-list` → `file` 的问题。
- **加了兜底护栏**：万一还有没覆盖到的写法解析出以 `v-model` 开头的属性名，直接 `throw` 并指出是哪一行文档，让构建失败而不是静默发布坏元数据。

另外把这些纯函数抽到了 `scripts/web-types-helper.ts`。因为 `build-web-types.ts` 在模块顶层就会真正跑一遍生成流程，单元测试如果直接 import 它，会在收集阶段真的往 `src/uni_modules/wot-ui/` 写 620KB 产物，而且上面那个护栏一旦 `throw` 会让测试文件在 import 阶段就崩掉，而不是干净地报一条测试失败。

#### 本次改动不涉及

- 不改任何组件源码，运行时行为零变化，只影响 IDE 提示用的元数据产物。
- 不改文档。解析器已经兼容文档现有的各种写法，按「一个 PR 只解决单个问题」保持 diff 最小。

### ☑️ 验证

**产物比对**（`pnpm build:web-types` 前后各生成一次，对比 104 个组件、1323 个 prop）：

| | 以 `v-model` 开头的属性名 |
| --- | --- |
| 修复前 | **46 处**（`wd-popup`、`wd-action-sheet`、`wd-calendar`、`wd-upload` …） |
| 修复后 | **0 处** |

```
wd-popup:        v-model      → model-value
wd-action-sheet: v-model      → model-value
wd-upload:       v-model:file → file-list
```

`attributes.json` 里以 `v-model` 开头的键同样从 **46 个降到 0 个**（`wd-popup/v-model` → `wd-popup/model-value`）。

**其他检查**

- 新增 `tests/scripts/web-types-helper.test.ts`，16 个用例覆盖各种写法、markdown 装饰、连字符修饰符截断回归、以及护栏抛错。
- 全量测试：107 个测试文件 / 1812 个用例全部通过。
- `pnpm type-check` 通过（唯一那条 error 在 `vite-plugins/vite-plugin-uni-conditional-compile.ts`，是本 PR 之前就存在的）。
- 改动文件均通过 ESLint 与 Prettier 校验。

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化文档参数到 IDE 属性名的解析，支持普通属性、驼峰及连字符格式。
  * 完善裸 `v-model` 和具名 `v-model` 的属性识别与转换。
  * 自动清理版本标记和 Markdown 装饰，避免生成无效属性名。
  * 对非法 `v-model` 写法提供错误提示，提升生成结果的可靠性。

* **测试**
  * 增加多种属性解析场景及异常输入的测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->