### PR TITLE
fix(select-picker): make modelValue optional

### DIFF
--- a/src/uni_modules/wot-ui/common/props.ts
+++ b/src/uni_modules/wot-ui/common/props.ts
@@ -16,6 +16,11 @@ export const makeRequiredProp = <T>(type: T) => ({
   required: true as const
 })
 
+export const makeOptionalProp = <T>(type: T) => ({
+  type,
+  default: undefined
+})
+
 export const makeArrayProp = <T>() => ({
   type: Array as PropType<T[]>,
   default: () => []

--- a/src/uni_modules/wot-ui/components/wd-select-picker/types.ts
+++ b/src/uni_modules/wot-ui/components/wd-select-picker/types.ts
@@ -1,5 +1,5 @@
 import type { ComponentPublicInstance, ExtractPropTypes, PropType } from 'vue'
-import { baseProps, makeArrayProp, makeBooleanProp, makeNumberProp, makeRequiredProp, makeStringProp } from '../../common/props'
+import { baseProps, makeArrayProp, makeBooleanProp, makeNumberProp, makeOptionalProp, makeStringProp } from '../../common/props'
 
 export type SelectPickerType = 'checkbox' | 'radio'
 
@@ -21,8 +21,13 @@ export const selectPickerProps = {
   loadingColor: makeStringProp('#4D80F0'),
   /** 点击遮罩是否关闭 */
   closeOnClickModal: makeBooleanProp(true),
-  /** 选中项，`type`类型为`checkbox`时，类型为 array；`type`为`radio` 时 ，类型为 number / boolean / string */
-  modelValue: makeRequiredProp([String, Number, Boolean, Array] as PropType<string | number | boolean | (string | number | boolean)[]>),
+  /**
+   * 选中项，可省略或传入 undefined
+   * 类型: string | number | boolean | (string | number | boolean)[] | undefined
+   * checkbox 类型传入数组，radio 类型传入 string | number | boolean
+   * 默认值: undefined
+   */
+  modelValue: makeOptionalProp([String, Number, Boolean, Array] as PropType<string | number | boolean | (string | number | boolean)[] | undefined>),
   /** 选择器数据，一维数组 */
   columns: makeArrayProp<Record<string, any>>(),
   /** 单复选选择器类型 */

--- a/src/uni_modules/wot-ui/components/wd-select-picker/wd-select-picker.vue
+++ b/src/uni_modules/wot-ui/components/wd-select-picker/wd-select-picker.vue
@@ -123,31 +123,29 @@ const props = defineProps(selectPickerProps)
 const emit = defineEmits(['change', 'cancel', 'confirm', 'update:modelValue', 'open', 'close', 'update:visible'])
 
 const pickerShow = ref<boolean>(false)
-const selectList = ref<Array<number | boolean | string> | number | boolean | string>([])
+const selectList = ref<Array<number | boolean | string> | number | boolean | string | undefined>([])
 const isConfirm = ref<boolean>(false)
-const lastSelectList = ref<Array<number | boolean | string> | number | boolean | string>([])
+const lastSelectList = ref<Array<number | boolean | string> | number | boolean | string | undefined>([])
 const filterVal = ref<string>('')
 const filterColumns = ref<Array<Record<string, any>>>([])
 const scrollTop = ref<number>(0) // 滚动位置
 
 const valueItemMap = computed(() => {
-  const map = new Map<string | number | boolean, Record<string, any>>()
+  const map = new Map<string | number | boolean | undefined, Record<string, any>>()
   const { columns, valueKey } = props
   columns.forEach((item) => {
     map.set(item[valueKey], item)
   })
   return map
 })
-
 const showHighlightText = computed(() => {
   return props.filterable && !!filterVal.value
 })
 
-function getModelValueWatchKey(value: string | number | boolean | (string | number | boolean)[]) {
-  if (props.type === 'checkbox') {
-    return isArray(value) ? value.join('|') : ''
-  }
-  return isDef(value) ? String(value) : ''
+function getModelValueWatchKey(value: string | number | boolean | (string | number | boolean)[] | undefined) {
+  if (!isDef(value)) return 'undefined'
+  if (isArray(value)) return `array:${JSON.stringify(value)}`
+  return `${typeof value}:${String(value)}`
 }
 
 function getColumnsWatchKey(columns: Record<string, any>[]) {
@@ -238,7 +236,7 @@ async function setScrollIntoView() {
 
 function noop() {}
 
-function getSelectedItem(value: string | number | boolean) {
+function getSelectedItem(value: string | number | boolean | undefined) {
   const { valueKey, labelKey } = props
   const selected = valueItemMap.value.get(value)
 
@@ -252,7 +250,7 @@ function getSelectedItem(value: string | number | boolean) {
   }
 }
 
-function valueFormat(value: string | number | boolean | (string | number | boolean)[]) {
+function valueFormat(value: string | number | boolean | (string | number | boolean)[] | undefined) {
   return props.type === 'checkbox' ? (isArray(value) ? value : []) : value
 }
 
@@ -310,7 +308,7 @@ function handleConfirm() {
       return getSelectedItem(item)
     })
   } else {
-    selectedItems = getSelectedItem(lastSelectList.value as string | number | boolean)
+    selectedItems = getSelectedItem(lastSelectList.value as string | number | boolean | undefined)
   }
   emit('update:modelValue', lastSelectList.value)
   emit('confirm', {

--- a/tests/components/wd-select-picker.test.ts
+++ b/tests/components/wd-select-picker.test.ts
@@ -11,6 +11,74 @@ const globalComponents = {
 }
 
 describe('WdSelectPicker', () => {
+  test('modelValue 默认值为 undefined', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      const propsWithoutModelValue: InstanceType<typeof WdSelectPicker>['$props'] = {}
+      const wrapper = mount(WdSelectPicker, {
+        props: propsWithoutModelValue,
+        global: {
+          components: globalComponents
+        }
+      })
+
+      expect(warn).not.toHaveBeenCalledWith(expect.stringContaining('[Vue warn]: Missing required prop: "modelValue"'))
+      expect(wrapper.vm.modelValue).toBeUndefined()
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  test('modelValue 从 undefined 切换为空字符串时刷新选中值', async () => {
+    const wrapper = mount(WdSelectPicker, {
+      props: {
+        type: 'radio',
+        columns: [{ value: '', label: '空选项' }]
+      },
+      global: {
+        components: globalComponents
+      }
+    })
+
+    await wrapper.setProps({ modelValue: '' })
+    await nextTick()
+
+    expect((wrapper.vm as any).selectList).toBe('')
+  })
+
+  test('多选 modelValue 的数组边界、分隔符和元素类型变化时刷新选中值', async () => {
+    const wrapper = mount(WdSelectPicker, {
+      props: {
+        modelValue: [''],
+        columns: [{ value: '', label: '空选项' }]
+      },
+      global: {
+        components: globalComponents
+      }
+    })
+
+    await wrapper.setProps({ modelValue: [] })
+    await nextTick()
+    expect((wrapper.vm as any).selectList).toEqual([])
+
+    await wrapper.setProps({ modelValue: ['a|b'] })
+    await nextTick()
+    expect((wrapper.vm as any).selectList).toEqual(['a|b'])
+
+    await wrapper.setProps({ modelValue: ['a', 'b'] })
+    await nextTick()
+    expect((wrapper.vm as any).selectList).toEqual(['a', 'b'])
+
+    await wrapper.setProps({ modelValue: [1] })
+    await nextTick()
+    expect((wrapper.vm as any).selectList).toEqual([1])
+
+    await wrapper.setProps({ modelValue: ['1'] })
+    await nextTick()
+    expect((wrapper.vm as any).selectList).toEqual(['1'])
+  })
+
   test('基本渲染', async () => {
     const wrapper = mount(WdSelectPicker, {
       props: {


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/wot-ui/wot-ui/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [x] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

https://github.com/wot-ui/wot-ui/issues/131

### 💡 需求背景和解决方案

多数情况下，表单提交字段的默认值都是空值，需要用户自行选择输入，但目前modelValue 属性强制要求必填，必须赋予默认值的做法欠妥。ts会因为字段类型存在undefined报错，开发阶段浏览器控制台也会因此显示警告。
但是以上报错与警告都是没有必要的。

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能改进**
  * 选择器组件支持未设置默认值的场景，`modelValue` 可为空。
  * 单选、多选模式均可正确处理空数组、字符串、数字及混合值。
  * `modelValue` 变化时，选中项列表可及时同步更新。

* **问题修复**
  * 未传入 `modelValue` 时，组件不再产生属性缺失警告。
  * 优化空值及不同类型值的处理，提升选择器使用稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->