### PR TITLE
docs: ✏️  优化 wwwads 占位展示

### DIFF
--- a/packages/vitepress-theme/src/theme/components/WwAds.vue
+++ b/packages/vitepress-theme/src/theme/components/WwAds.vue
@@ -11,48 +11,147 @@ const wwadsSlot = ref<HTMLElement | null>(null)
 const showSupportCard = ref(false)
 const supportCardDismissed = ref(false)
 
+const BLOCK_CONFIRMATION_DELAY = 200
+
 let wwadsScript: HTMLScriptElement | null = null
-let verificationTimer: number | undefined
+let adBait: HTMLElement | null = null
+let contentObserver: MutationObserver | null = null
+let viewportObserver: IntersectionObserver | null = null
+let resizeObserver: ResizeObserver | null = null
+let verificationFrame: number | undefined
+let confirmationTimer: number | undefined
+let hostInViewport = false
+
+function cancelVerification() {
+  if (verificationFrame !== undefined) {
+    window.cancelAnimationFrame(verificationFrame)
+    verificationFrame = undefined
+  }
+  if (confirmationTimer !== undefined) {
+    window.clearTimeout(confirmationTimer)
+    confirmationTimer = undefined
+  }
+}
 
 function revealSupportCard() {
-  if (verificationTimer !== undefined) {
-    window.clearTimeout(verificationTimer)
-    verificationTimer = undefined
-  }
+  cancelVerification()
+  contentObserver?.disconnect()
+  viewportObserver?.disconnect()
+  resizeObserver?.disconnect()
   showSupportCard.value = true
+}
+
+function isExplicitlyHidden(element: Element) {
+  const style = window.getComputedStyle(element)
+
+  return style.display === 'none' || style.visibility === 'hidden' || style.visibility === 'collapse' || Number(style.opacity) === 0
+}
+
+function isVisible(element: Element) {
+  const rect = element.getBoundingClientRect()
+
+  return !isExplicitlyHidden(element) && rect.width > 0 && rect.height > 0
 }
 
 function hasVisibleAd() {
   const element = wwadsSlot.value
   if (!element || element.childElementCount === 0) return false
 
-  const style = window.getComputedStyle(element)
-  const rect = element.getBoundingClientRect()
+  const knownCreativeElements = Array.from(element.querySelectorAll(':scope > .wwads-img, :scope > .wwads-content .wwads-text'))
+  const contentElements = knownCreativeElements.length
+    ? knownCreativeElements
+    : Array.from(element.children).filter((child) => !child.classList.contains('wwads-hide'))
 
-  return style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0' && rect.width > 0 && rect.height > 0
+  return isVisible(element) && contentElements.some(isVisible)
+}
+
+function hasBlockingEvidence() {
+  const slot = wwadsSlot.value
+  const host = wwadsHost.value
+  if (!hostInViewport || !host || !slot) return false
+  if (slot.parentElement !== host) return false
+  if (slot.childElementCount > 0 && hasVisibleAd()) return false
+
+  if (isExplicitlyHidden(slot) || adBait?.parentElement !== host || !isVisible(adBait)) return true
+
+  return slot.childElementCount > 0
+}
+
+function confirmBlocking() {
+  confirmationTimer = undefined
+  if (hasBlockingEvidence()) revealSupportCard()
 }
 
 function verifyAd() {
-  verificationTimer = undefined
-  if (!hasVisibleAd()) revealSupportCard()
+  verificationFrame = undefined
+  if (!hasBlockingEvidence()) {
+    if (confirmationTimer !== undefined) {
+      window.clearTimeout(confirmationTimer)
+      confirmationTimer = undefined
+    }
+    return
+  }
+
+  if (confirmationTimer === undefined) {
+    confirmationTimer = window.setTimeout(confirmBlocking, BLOCK_CONFIRMATION_DELAY)
+  }
+}
+
+function scheduleVerification() {
+  if (!hostInViewport || verificationFrame !== undefined) return
+
+  verificationFrame = window.requestAnimationFrame(verifyAd)
+}
+
+function observeAdContent() {
+  const slot = wwadsSlot.value
+  if (!slot) return
+
+  resizeObserver?.disconnect()
+  resizeObserver?.observe(slot)
+  if (adBait) resizeObserver?.observe(adBait)
+  Array.from(slot.children).forEach((child) => resizeObserver?.observe(child))
+  scheduleVerification()
 }
 
 onMounted(() => {
-  if (!wwadsId || !wwadsHost.value) return
+  const host = wwadsHost.value
+  const slot = wwadsSlot.value
+  if (!wwadsId || !host || !slot) return
+
+  adBait = document.createElement('div')
+  adBait.className = 'adsbox ad-banner ad-placement'
+  adBait.setAttribute('aria-hidden', 'true')
+  adBait.style.cssText = 'position:absolute;left:-10000px;width:1px;height:1px;pointer-events:none;'
+  host.appendChild(adBait)
+
+  // 空广告位可能源于懒加载或网络问题，只有明确的隐藏证据才视为拦截。
+  contentObserver = new MutationObserver(observeAdContent)
+  contentObserver.observe(slot, { attributes: true, attributeFilter: ['class', 'hidden', 'style'], childList: true, subtree: true })
+
+  resizeObserver = new ResizeObserver(scheduleVerification)
+  observeAdContent()
+
+  viewportObserver = new IntersectionObserver(([entry]) => {
+    hostInViewport = entry.isIntersecting
+    if (hostInViewport) scheduleVerification()
+  })
+  viewportObserver.observe(host)
 
   wwadsScript = document.createElement('script')
   wwadsScript.src = 'https://cdn.wwads.cn/js/makemoney.js'
   wwadsScript.async = true
-  wwadsScript.onerror = revealSupportCard
-  wwadsHost.value.appendChild(wwadsScript)
-
-  // 网络请求成功后，广告内容仍可能被拦截器通过样式规则隐藏。
-  verificationTimer = window.setTimeout(verifyAd, 3000)
+  wwadsScript.onerror = scheduleVerification
+  host.appendChild(wwadsScript)
 })
 
 onBeforeUnmount(() => {
-  if (verificationTimer !== undefined) window.clearTimeout(verificationTimer)
+  cancelVerification()
+  contentObserver?.disconnect()
+  viewportObserver?.disconnect()
+  resizeObserver?.disconnect()
   wwadsScript?.remove()
+  adBait?.remove()
 })
 </script>
 

--- a/tests/vitepress-theme/ww-ads.test.ts
+++ b/tests/vitepress-theme/ww-ads.test.ts
@@ -1,0 +1,243 @@
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import WwAds from '../../packages/vitepress-theme/src/theme/components/WwAds.vue'
+import { wotThemeOptionsKey } from '../../packages/vitepress-theme/src/theme/options'
+
+describe('WwAds', () => {
+  let intersectionCallback: IntersectionObserverCallback
+  let mutationCallback: MutationCallback
+  let resizeCallback: ResizeObserverCallback
+  let animationFrameCallback: FrameRequestCallback | undefined
+  let hiddenElements: Set<Element>
+
+  beforeEach(() => {
+    hiddenElements = new Set()
+    vi.useFakeTimers()
+
+    class IntersectionObserverMock {
+      constructor(callback: IntersectionObserverCallback) {
+        intersectionCallback = callback
+      }
+
+      observe() {}
+      disconnect() {}
+    }
+
+    class MutationObserverMock {
+      constructor(callback: MutationCallback) {
+        mutationCallback = callback
+      }
+
+      observe() {}
+      disconnect() {}
+    }
+
+    class ResizeObserverMock {
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallback = callback
+      }
+
+      observe() {}
+      disconnect() {}
+    }
+
+    vi.stubGlobal('IntersectionObserver', IntersectionObserverMock)
+    vi.stubGlobal('MutationObserver', MutationObserverMock)
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock)
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      animationFrameCallback = callback
+      return 1
+    })
+    vi.spyOn(window, 'getComputedStyle').mockImplementation((element) => {
+      return {
+        display: hiddenElements.has(element) ? 'none' : 'block',
+        visibility: 'visible',
+        opacity: '1'
+      } as CSSStyleDeclaration
+    })
+    vi.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function () {
+      return {
+        width: hiddenElements.has(this) ? 0 : 100,
+        height: hiddenElements.has(this) ? 0 : 100
+      } as DOMRect
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  function mountAds() {
+    return mount(WwAds, {
+      global: {
+        provide: {
+          [wotThemeOptionsKey as symbol]: {
+            ads: { wwadsId: '372' },
+            specialSponsor: false
+          }
+        },
+        stubs: {
+          AsideSponsors: true
+        }
+      }
+    })
+  }
+
+  function enterViewport() {
+    intersectionCallback([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver)
+  }
+
+  async function verifyAndConfirm() {
+    flushAnimationFrame()
+    vi.advanceTimersByTime(200)
+    await nextTick()
+  }
+
+  function flushAnimationFrame() {
+    const callback = animationFrameCallback
+    animationFrameCallback = undefined
+    callback?.(0)
+  }
+
+  function notifyContentChange() {
+    mutationCallback([], {} as MutationObserver)
+  }
+
+  test('does not treat an empty slot or script failure as blocking', async () => {
+    const wrapper = mountAds()
+    enterViewport()
+
+    wrapper.find('script').element.dispatchEvent(new Event('error'))
+    await verifyAndConfirm()
+
+    expect(wrapper.find('.site-support-card').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  test('detects an empty slot explicitly hidden by CSS', async () => {
+    const wrapper = mountAds()
+    hiddenElements.add(wrapper.find('.wwads-cn').element)
+    enterViewport()
+    await verifyAndConfirm()
+
+    expect(wrapper.find('.site-support-card').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  test('detects a blocked local ad bait', async () => {
+    const wrapper = mountAds()
+    hiddenElements.add(wrapper.find('.adsbox').element)
+    enterViewport()
+    await verifyAndConfirm()
+
+    expect(wrapper.find('.site-support-card').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  test('keeps a visible creative when only the local bait is hidden', async () => {
+    const wrapper = mountAds()
+    const slot = wrapper.find('.wwads-cn').element
+    const creative = document.createElement('a')
+    creative.className = 'wwads-img'
+    slot.appendChild(creative)
+    hiddenElements.add(wrapper.find('.adsbox').element)
+    notifyContentChange()
+    enterViewport()
+    await verifyAndConfirm()
+
+    expect(wrapper.find('.site-support-card').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  test('ignores WWAds controls when checking creative visibility', async () => {
+    const wrapper = mountAds()
+    const slot = wrapper.find('.wwads-cn').element
+    const creative = document.createElement('a')
+    const closeControl = document.createElement('a')
+    creative.className = 'wwads-img'
+    closeControl.className = 'wwads-hide'
+    slot.append(creative, closeControl)
+    hiddenElements.add(creative)
+    notifyContentChange()
+    enterViewport()
+    await verifyAndConfirm()
+
+    expect(wrapper.find('.site-support-card').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  test('keeps a visible WWAds creative', async () => {
+    const wrapper = mountAds()
+    const slot = wrapper.find('.wwads-cn').element
+    const creative = document.createElement('a')
+    creative.className = 'wwads-img'
+    slot.appendChild(creative)
+    notifyContentChange()
+    enterViewport()
+    await verifyAndConfirm()
+
+    expect(wrapper.find('.site-support-card').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  test('ignores a transiently hidden creative', async () => {
+    const wrapper = mountAds()
+    const slot = wrapper.find('.wwads-cn').element
+    const creative = document.createElement('a')
+    creative.className = 'wwads-img'
+    slot.appendChild(creative)
+    hiddenElements.add(creative)
+    notifyContentChange()
+    enterViewport()
+    flushAnimationFrame()
+
+    hiddenElements.delete(creative)
+    resizeCallback([], {} as ResizeObserver)
+    flushAnimationFrame()
+    vi.advanceTimersByTime(200)
+    await nextTick()
+
+    expect(wrapper.find('.site-support-card').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  test('detects creative content hidden after insertion', async () => {
+    const wrapper = mountAds()
+    const slot = wrapper.find('.wwads-cn').element
+    const creative = document.createElement('a')
+    creative.className = 'wwads-img'
+    slot.appendChild(creative)
+    notifyContentChange()
+    enterViewport()
+    await verifyAndConfirm()
+    expect(wrapper.find('.site-support-card').exists()).toBe(false)
+
+    hiddenElements.add(creative)
+    resizeCallback([], {} as ResizeObserver)
+    await verifyAndConfirm()
+
+    expect(wrapper.find('.site-support-card').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  test('does not treat a user-dismissed WWAds slot as blocking', async () => {
+    const wrapper = mountAds()
+    const slot = wrapper.find('.wwads-cn').element
+    const creative = document.createElement('a')
+    creative.className = 'wwads-img'
+    slot.appendChild(creative)
+    notifyContentChange()
+    enterViewport()
+    await verifyAndConfirm()
+
+    slot.remove()
+    resizeCallback([], {} as ResizeObserver)
+    await verifyAndConfirm()
+
+    expect(wrapper.find('.site-support-card').exists()).toBe(false)
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/wot-ui/wot-ui/blob/master/.github/CONTRIBUTING.md)
-->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [x] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [x] 代码重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🤖 AI 辅助开发声明（请选择一项）

- [ ] 未使用：未使用 AI 工具参与本 PR 的分析、实现、测试或文档编写
- [ ] 辅助使用：仅用于检索、问答、方案讨论、翻译或润色，未将 AI 生成内容直接纳入本 PR
- [ ] 部分生成：AI 生成或修改的代码、测试、配置或文档已纳入本 PR，提交者已完成审查与验证
- [x] 主要生成：AI 或 AI Agent 参与了主要实现或产出，提交者负责需求定义、结果审查、测试验证和后续维护
- [ ] 其他情况（请说明）

AI 工具/模型及参与范围（可选）：

Codex（GPT-5）参与了问题分析、广告检测逻辑实现、测试用例编写和代码审查。

人工审查、测试与验证情况（可选）：

已对广告懒加载、广告内容隐藏、广告诱饵、用户主动关闭广告等场景进行人工审查，并完成定向测试、全量测试、ESLint 检查和主题包构建验证。

### 🔗 相关 Issue

暂无，由站点广告拦截提示误报反馈引出。

### 💡 需求背景和解决方案

部分用户未使用广告拦截插件时，也会看到“感谢你支持 Wot UI”的提示。

原有逻辑在组件挂载后固定等待 3 秒，只要广告节点为空或不可见，就直接判定为广告被拦截。由于 WWAds 使用懒加载、广告位可能尚未进入视口，或者网络请求存在延迟，因此会产生误报。

本次调整：

1. 移除固定 3 秒后直接判定拦截的逻辑。
2. 广告位进入视口后才进行检测。
3. 使用 `MutationObserver` 和 `ResizeObserver` 监听广告内容及尺寸变化。
4. 空广告位、脚本加载失败、网络异常不再直接显示拦截提示。
5. 增加本地广告诱饵，用于识别明确的广告过滤行为。
6. 真实广告内容可见时优先视为正常，避免诱饵被隐藏导致误报。
7. 排除 WWAds 的关闭按钮等控制节点，避免将其误判为广告内容。
8. 用户主动关闭广告后，不再显示支持提示。
9. 对隐藏状态增加 200ms 二次确认，避免瞬时布局变化造成误报。

本次没有新增或修改公开 API，也没有视觉样式变化，因此无需补充文档、Demo 或截图。

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 优化广告拦截检测，仅在确认广告被拦截或广告位异常隐藏时显示支持卡片。
  - 支持识别多种广告加载失败及隐藏场景，减少误判。

- **问题修复**
  - 避免因广告加载延迟、短暂隐藏或可见广告内容而错误显示支持卡片。
  - 组件卸载后会正确停止检测，提升页面稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->