### PR TITLE
fix: 修复 SelectPicker 中文 value 滚动定位报错

### DIFF
--- a/src/uni_modules/wot-ui/components/wd-select-picker/wd-select-picker.vue
+++ b/src/uni_modules/wot-ui/components/wd-select-picker/wd-select-picker.vue
@@ -37,7 +37,7 @@
             placement="right"
             @change="handleChange"
           >
-            <view v-for="item in filterColumns" :key="item[valueKey]" :id="'check' + item[valueKey]" class="wd-select-picker__checkbox-item">
+            <view v-for="(item, index) in filterColumns" :key="item[valueKey]" :id="'check' + index" class="wd-select-picker__checkbox-item">
               <wd-checkbox :name="item[valueKey]" :disabled="item.disabled" custom-label-class="wd-select-picker__checkbox-label">
                 <block v-if="showHighlightText">
                   <block v-for="text in item[labelKey]" :key="text.label">
@@ -63,7 +63,7 @@
             type="dot"
             @change="handleChange"
           >
-            <view v-for="(item, index) in filterColumns" :key="index" :id="'radio' + item[valueKey]" class="wd-select-picker__radio-item">
+            <view v-for="(item, index) in filterColumns" :key="index" :id="'radio' + index" class="wd-select-picker__radio-item">
               <wd-radio :value="item[valueKey]" :disabled="item.disabled" custom-label-class="wd-select-picker__radio-label">
                 <block v-if="showHighlightText">
                   <block v-for="text in item[labelKey]" :key="text.label">
@@ -208,15 +208,20 @@ const { proxy } = getCurrentInstance() as any
 
 async function setScrollIntoView() {
   let wraperSelector: string = ''
-  let targetSelector: string = ''
+  let targetSelectorPrefix: string = ''
+  let selectedValue: string | number | boolean | undefined
   if (isDef(selectList.value) && selectList.value !== '' && !isArray(selectList.value)) {
     wraperSelector = '#wd-radio-group'
-    targetSelector = `#radio${selectList.value}`
+    targetSelectorPrefix = '#radio'
+    selectedValue = selectList.value
   } else if (isArray(selectList.value) && selectList.value.length > 0) {
     wraperSelector = '#wd-checkbox-group'
-    targetSelector = `#check${selectList.value[0]}`
+    targetSelectorPrefix = '#check'
+    selectedValue = selectList.value[0]
   }
-  if (wraperSelector && targetSelector) {
+  const targetIndex = filterColumns.value.findIndex((item) => item[props.valueKey] === selectedValue)
+  if (wraperSelector && targetSelectorPrefix && targetIndex >= 0) {
+    const targetSelector = `${targetSelectorPrefix}${targetIndex}`
     await pause(2000 / 30)
     const [scrollView, wraper, target] = await Promise.all([
       getRect('.wd-select-picker__wrapper', false, proxy),

--- a/tests/components/wd-select-picker.test.ts
+++ b/tests/components/wd-select-picker.test.ts
@@ -46,6 +46,37 @@ describe('WdSelectPicker', () => {
     expect(emitted['open']).toBeTruthy()
   })
 
+  test('中文 value 使用安全索引滚动定位', async () => {
+    vi.useFakeTimers()
+    const wrapper = mount(WdSelectPicker, {
+      props: {
+        modelValue: ['卡皮巴拉'],
+        columns: [
+          { value: '卡皮巴拉', label: '卡皮巴拉' },
+          { value: '水豚', label: '水豚' }
+        ],
+        visible: true,
+        scrollIntoView: false
+      },
+      global: {
+        components: globalComponents
+      }
+    })
+
+    const createSelectorQuery = vi.mocked(uni.createSelectorQuery)
+    createSelectorQuery.mockClear()
+    const scrollPromise = (wrapper.vm as any).setScrollIntoView()
+    await vi.advanceTimersByTimeAsync(100)
+    await scrollPromise
+
+    const selectors = createSelectorQuery.mock.results.map((result) => {
+      const query = result.value as any
+      return query.select.mock.calls[0][0]
+    })
+    expect(selectors).toEqual(['.wd-select-picker__wrapper', '#wd-checkbox-group', '#check0'])
+    vi.useRealTimers()
+  })
+
   test('自定义标题', async () => {
     const title = '请选择'
     const wrapper = mount(WdSelectPicker, {


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/wot-ui/wot-ui/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

Closes https://github.com/wot-ui/wot-ui/issues/154

### 💡 需求背景和解决方案

`wd-select-picker` 开启 `scroll-into-view` 时，会将选中的业务 `value` 直接拼接为节点 ID 和选择器：

```ts
targetSelector = `#check${selectList.value[0]}`
```

当 `value` 为中文或包含选择器特殊字符时，例如 `卡皮巴拉`，微信小程序中的 `createSelectorQuery().select('#check卡皮巴拉')` 无法查询到对应节点，`getRect` 随后抛出未捕获的 `No nodes found` 错误，导致打开弹层时报错。

本次修改：

1. 复选和单选选项的内部节点 ID 改为基于列表索引生成，例如 `check0`、`radio0`，不再使用业务 `value` 构造选择器。
2. 滚动定位前，根据选中的 `value` 在当前选项列表中查找对应索引，再使用安全的索引选择器查询节点。
3. 当选中值不存在于当前选项列表时，跳过滚动定位，避免查询不存在的节点。
4. 保持组件对外的 `value`、`value-key` 和选中逻辑不变。
5. 增加中文 value 的回归测试，确认滚动定位使用 `#check0`，不再使用 `#check卡皮巴拉`。

该修复同时覆盖 `checkbox` 和 `radio` 两种模式，也可以避免空格、`.`、`#`、`:` 等特殊字符导致的同类问题。

### 🧪 测试结果

已完成以下验证：

```bash
pnpm test:h5 --run tests/components/wd-select-picker.test.ts
pnpm exec eslint src/uni_modules/wot-ui/components/wd-select-picker/wd-select-picker.vue tests/components/wd-select-picker.test.ts
pnpm build:mp-weixin
```

验证结果：

- `wd-select-picker` 组件测试 14 项全部通过。
- ESLint 检查通过。
- 微信小程序构建通过。
- 在微信开发者工具中使用中文 value 实际测试通过。
- 打开弹层时能够正常定位到已选中项，不再出现 `No nodes found`。

### 📷 修改前后对比

#### 修复前

使用中文 value 打开弹层时，控制台抛出 `No nodes found` 错误。

<img width="1053" height="774" alt="image" src="https://github.com/user-attachments/assets/9cd17054-6140-466a-9f77-b8e9da59ae19" />


#### 修复后

使用相同数据打开弹层正常，已选中项正确展示并完成滚动定位，控制台无报错。

<img width="996" height="722" alt="image" src="https://github.com/user-attachments/assets/51cbf039-4a6a-4701-b9de-bd25c8d339ef" />

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复选择器列表项包含中文值时，滚动定位可能失效的问题。
  * 优化单选和多选列表项的定位，确保选中项能够准确滚动到可视区域。

* **Tests**
  * 新增中文选项值滚动定位的测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->