### PR TITLE
fix: 🐛 Rate 兼容低版本 iOS 渐变图标显示

### DIFF
--- a/src/uni_modules/wot-ui/components/wd-rate/index.scss
+++ b/src/uni_modules/wot-ui/components/wd-rate/index.scss
@@ -29,6 +29,8 @@ $rate-item-space: var(--wot-rate-item-space, $spacing-extra-tight) !default;
 
   @include edeep(item-star) {
     -webkit-background-clip: text !important;
+    background-clip: text !important;
+    -webkit-text-fill-color: transparent;
     color: transparent;
     background: $rate-color;
     font-size: $rate-size;


### PR DESCRIPTION

<!--
请务必阅读[贡献指南](https://github.com/wot-ui/wot-ui/blob/master/.github/CONTRIBUTING.md)
-->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🤖 AI 辅助开发声明（请选择一项）

- [ ] 未使用：未使用 AI 工具参与本 PR 的分析、实现、测试或文档编写
- [ ] 辅助使用：仅用于检索、问答、方案讨论、翻译或润色，未将 AI 生成内容直接纳入本 PR
- [x] 部分生成：AI 生成或修改的代码、测试、配置或文档已纳入本 PR，提交者已完成审查与验证
- [ ] 主要生成：AI 或 AI Agent 参与了主要实现或产出，提交者负责需求定义、结果审查、测试验证和后续维护
- [ ] 其他情况（请说明）

AI 工具/模型及参与范围（可选）：

使用 AI Agent 协助分析低版本 iOS WebKit 下 Rate 组件渐变图标不显示的问题，并生成兼容性样式修改建议。

人工审查、测试与验证情况（可选）：

已人工确认问题原因及修改范围，并完成微信小程序构建验证和 Rate 组件单元测试验证。

### 🔗 相关 Issue

暂无，问题来源于用户反馈。

### 💡 需求背景和解决方案

低版本 iOS 下，`wd-rate` 的渐变星星可能无法正常显示，导致评分组件中的图标区域为空白。

本次为 Rate 图标补充完整的文字背景裁剪兼容样式：

```scss
-webkit-background-clip: text !important;
background-clip: text !important;
-webkit-text-fill-color: transparent;
color: transparent;
```

不涉及组件 API、交互逻辑或 TypeScript 定义变更。微信开发者工具上传代码时，建议同时勾选“上传代码时样式自动补全”。

验证结果：

- 微信小程序构建通过
- `wd-rate` 单元测试 29/29 通过
- ESLint 检查通过

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **样式优化**
  * 优化评分组件图标的渐变文字显示效果。
  * 改善不同浏览器环境下评分图标的颜色透明与背景裁剪表现。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->